### PR TITLE
Add response models for previously-untyped endpoints

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -4,7 +4,15 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.auth import authenticate_user, create_access_token, create_user, get_current_user
 from app.models import User, UserWord, UserSituation, Conversation
-from app.schemas import LoginRequest, LoginResponse, RegisterRequest, UserProfileResponse, AltLanguageRequest
+from app.schemas import (
+    AltLanguageRequest,
+    LoginRequest,
+    LoginResponse,
+    RegisterRequest,
+    ResetPasswordResponse,
+    ResetProgressResponse,
+    UserProfileResponse,
+)
 
 router = APIRouter()
 
@@ -202,7 +210,7 @@ async def reset_password(request: dict, db: Session = Depends(get_db)):
     return {"reset": True}
 
 
-@router.post("/admin-reset-password")
+@router.post("/admin-reset-password", response_model=ResetPasswordResponse)
 async def admin_reset_password(
     request: dict,
     current_user: User = Depends(get_current_user),
@@ -224,10 +232,10 @@ async def admin_reset_password(
 
     user.password_hash = get_password_hash(new_password)
     db.commit()
-    return {"reset": True, "email": email}
+    return ResetPasswordResponse(reset=True, email=email)
 
 
-@router.post("/reset-progress")
+@router.post("/reset-progress", response_model=ResetProgressResponse)
 async def reset_progress(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
@@ -245,9 +253,9 @@ async def reset_progress(
     deleted_conversations = db.query(Conversation).filter(Conversation.user_id == current_user.id).delete()
     db.commit()
 
-    return {
-        "reset": True,
-        "deleted_words": deleted_words,
-        "deleted_situations": deleted_situations,
-        "deleted_conversations": deleted_conversations,
-    }
+    return ResetProgressResponse(
+        reset=True,
+        deleted_words=deleted_words,
+        deleted_situations=deleted_situations,
+        deleted_conversations=deleted_conversations,
+    )

--- a/app/api/v1/onboarding.py
+++ b/app/api/v1/onboarding.py
@@ -7,6 +7,11 @@ from datetime import datetime, timezone
 from app.database import get_db
 from app.auth import get_current_user
 from app.models import User, Situation, UserWord, UserSituation, Word
+from app.schemas import (
+    AvailableCategoriesResponse,
+    AvailableCategory,
+    UpdateAnimationTypesResponse,
+)
 from app.data.grammar_situations import GRAMMAR_SITUATIONS, get_all_grammar_situation_ids, GL_VL_THRESHOLDS
 import logging
 
@@ -193,7 +198,7 @@ async def get_onboarding_status(
     )
 
 
-@router.get("/available-categories")
+@router.get("/available-categories", response_model=AvailableCategoriesResponse)
 async def get_available_categories(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
@@ -248,21 +253,21 @@ async def get_available_categories(
         },
     }
 
-    result = []
+    result: List[AvailableCategory] = []
     for type_id, type_info in allowed_types.items():
         # Verify animation type exists in database
         exists = db.query(Situation).filter(Situation.animation_type == type_id).first()
         if exists:
-            result.append({
-                "id": type_id,
-                "name": type_info["name"],
-                "description": type_info["description"]
-            })
+            result.append(AvailableCategory(
+                id=type_id,
+                name=type_info["name"],
+                description=type_info["description"],
+            ))
 
     # Sort by name for consistent ordering
-    result.sort(key=lambda x: x["name"])
+    result.sort(key=lambda c: c.name)
 
-    return {"categories": result}
+    return AvailableCategoriesResponse(categories=result)
 
 
 class UpdateAnimationTypesRequest(BaseModel):
@@ -270,7 +275,7 @@ class UpdateAnimationTypesRequest(BaseModel):
     action: str  # 'add' or 'remove'
 
 
-@router.patch("/animation-types")
+@router.patch("/animation-types", response_model=UpdateAnimationTypesResponse)
 async def update_animation_types(
     request: UpdateAnimationTypesRequest,
     current_user: User = Depends(get_current_user),
@@ -307,4 +312,4 @@ async def update_animation_types(
     current_user.selected_animation_types = current
     db.commit()
 
-    return {"selected_animation_types": current}
+    return UpdateAnimationTypesResponse(selected_animation_types=current)

--- a/app/api/v1/situations.py
+++ b/app/api/v1/situations.py
@@ -12,8 +12,13 @@ from app.schemas import (
     StartSituationResponse,
     CompleteSituationResponse,
     AdminSkipEncounterResponse,
+    DailyUsageResponse,
     GrammarConfigResponse,
-    WordSchema
+    GrammarCompletedResponse,
+    GrammarGate,
+    GrammarGatesResponse,
+    GrammarUnit,
+    WordSchema,
 )
 from app.services.word_selection_service import (
     select_words_for_situation,
@@ -282,7 +287,7 @@ async def get_selected_situations(
     return result
 
 
-@router.get("/grammar-gates")
+@router.get("/grammar-gates", response_model=GrammarGatesResponse)
 async def get_grammar_gates(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
@@ -320,15 +325,15 @@ async def get_grammar_gates(
         ).first() is not None
         gate["resume_phase"] = "voice-chat" if has_active_voice else "learn"
 
-    return {
-        "vocab_level": vocab_level,
-        "grammar_level": grammar_level,
-        "is_gated": gate is not None,
-        "gate": gate,
-    }
+    return GrammarGatesResponse(
+        vocab_level=vocab_level,
+        grammar_level=grammar_level,
+        is_gated=gate is not None,
+        gate=GrammarGate(**gate) if gate else None,
+    )
 
 
-@router.get("/grammar-completed")
+@router.get("/grammar-completed", response_model=GrammarCompletedResponse)
 async def get_completed_grammar(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
@@ -342,33 +347,33 @@ async def get_completed_grammar(
         ).all()
     }
 
-    result = []
+    result: List[GrammarUnit] = []
     for gl in sorted(GL_VL_THRESHOLDS.keys()):
         from app.data.grammar_situations import get_situations_for_gl
         situations_at_gl = get_situations_for_gl(gl)
         total_lessons = len(situations_at_gl)
         completed_lessons = sum(1 for sid in situations_at_gl if sid in completed_situations)
 
-        result.append({
-            "grammar_level": gl,
-            "title": GL_TITLES[gl],
-            "vl_threshold": GL_VL_THRESHOLDS[gl],
-            "has_content": total_lessons > 0,
-            "completed": total_lessons > 0 and completed_lessons == total_lessons,
-            "total_lessons": total_lessons,
-            "completed_lessons": completed_lessons,
-        })
+        result.append(GrammarUnit(
+            grammar_level=gl,
+            title=GL_TITLES[gl],
+            vl_threshold=GL_VL_THRESHOLDS[gl],
+            has_content=total_lessons > 0,
+            completed=total_lessons > 0 and completed_lessons == total_lessons,
+            total_lessons=total_lessons,
+            completed_lessons=completed_lessons,
+        ))
 
-    return {"grammar_units": result}
+    return GrammarCompletedResponse(grammar_units=result)
 
 
-@router.get("/daily-usage")
+@router.get("/daily-usage", response_model=DailyUsageResponse)
 async def get_daily_usage(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
     """Get today's encounter usage for the current user."""
-    return get_daily_encounter_usage(db, current_user.id)
+    return DailyUsageResponse(**get_daily_encounter_usage(db, current_user.id))
 
 
 @router.get("", response_model=list[SituationListItem])

--- a/app/api/v1/user_words.py
+++ b/app/api/v1/user_words.py
@@ -5,19 +5,19 @@ from typing import List, Optional
 from app.database import get_db
 from app.auth import get_current_user
 from app.models import User, UserWord, Word
-from app.schemas import UserWordSchema, TypedCorrectRequest, HintRequest
+from app.schemas import (
+    DemoteWordResponse,
+    HintRequest,
+    HintResponse,
+    MessageOnlyResponse,
+    TypedCorrectRequest,
+    UnknownWordSchema,
+    UnknownWordsResponse,
+    UserWordSchema,
+)
 from app.services.alt_language_service import apply_alt_language
-from pydantic import BaseModel
 
 router = APIRouter()
-
-
-class UnknownWordSchema(BaseModel):
-    word_id: str
-    spanish: str
-    english: str
-    word_category: Optional[str]  # 'high_frequency' or 'encounter'
-    frequency_rank: Optional[int]
 
 
 @router.get("", response_model=list[UserWordSchema])
@@ -41,9 +41,11 @@ async def get_user_words(
         word = word_dict.get(uw.word_id)
         if word:
             result.append(UserWordSchema(
+                id=uw.word_id,
                 word_id=uw.word_id,
                 spanish=word.spanish,
                 english=word.english,
+                notes=word.notes,
                 seen_count=uw.seen_count,
                 typed_correct_count=uw.typed_correct_count,
                 spoken_correct_count=uw.spoken_correct_count,
@@ -58,7 +60,7 @@ async def get_user_words(
     return result
 
 
-@router.post("/typed-correct")
+@router.post("/typed-correct", response_model=MessageOnlyResponse)
 async def mark_typed_correct(
     request: TypedCorrectRequest,
     current_user: User = Depends(get_current_user),
@@ -97,7 +99,7 @@ async def mark_typed_correct(
     return {"message": "Updated"}
 
 
-@router.post("/hint")
+@router.post("/hint", response_model=HintResponse)
 async def record_hint(
     request: HintRequest,
     current_user: User = Depends(get_current_user),
@@ -115,7 +117,7 @@ async def record_hint(
     return {"hint_count": 0}
 
 
-@router.post("/demote")
+@router.post("/demote", response_model=DemoteWordResponse)
 async def demote_word(
     request: HintRequest,
     current_user: User = Depends(get_current_user),
@@ -144,7 +146,7 @@ async def demote_word(
     return {"word_id": request.word_id, "old_level": old_level, "new_level": new_level}
 
 
-@router.get("/unknown", response_model=dict)
+@router.get("/unknown", response_model=UnknownWordsResponse)
 async def get_unknown_words(
     category: Optional[str] = Query(None, description="Filter by category: 'high_frequency' or 'encounter'"),
     current_user: User = Depends(get_current_user),
@@ -179,19 +181,20 @@ async def get_unknown_words(
     
     for word in unknown_words:
         word_data = UnknownWordSchema(
+            id=word.id,
             word_id=word.id,
             spanish=word.spanish,
             english=word.english,
             word_category=word.word_category,
             frequency_rank=word.frequency_rank
         )
-        
+
         if word.word_category == 'high_frequency':
             high_frequency.append(word_data)
         elif word.word_category == 'encounter':
             encounter.append(word_data)
-    
-    return {
-        "high_frequency": high_frequency,
-        "encounter": encounter
-    }
+
+    return UnknownWordsResponse(
+        high_frequency=high_frequency,
+        encounter=encounter,
+    )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,7 +1,29 @@
-from pydantic import BaseModel, EmailStr
-from typing import List, Optional
+from pydantic import BaseModel, EmailStr, Field
+from typing import Any, Dict, List, Literal, Optional
 from datetime import datetime
 from uuid import UUID
+
+
+WordStatus = Literal["learning", "mastered"]
+
+
+# Pydantic 2 emits `{type: object}` for Dict[str, Any], which openapi-typescript
+# interprets as `Record<string, never>`. These helpers post-process the JSON
+# schema to inject `additionalProperties: true` *inside* the anyOf object
+# variant so generated clients see a real "object with unknown values" shape.
+def _freeform_object_schema(schema: dict) -> None:
+    for variant in schema.get("anyOf", []):
+        if variant.get("type") == "object":
+            variant["additionalProperties"] = True
+            return
+    schema["additionalProperties"] = True
+
+
+def _freeform_object_list_schema(schema: dict) -> None:
+    for variant in schema.get("anyOf", []):
+        if variant.get("type") == "array":
+            variant.setdefault("items", {"type": "object"})["additionalProperties"] = True
+            return
 
 
 # Auth schemas
@@ -104,21 +126,42 @@ class AdminSkipEncounterResponse(BaseModel):
 
 # User Words schemas
 class UserWordSchema(BaseModel):
+    # `id` and `word_id` hold the same value. `id` is included so FE `Word`-based
+    # types can read the field under its conventional name without casting;
+    # `word_id` is kept for backward compatibility with existing consumers.
+    id: str
     word_id: str
     spanish: str
     english: str
+    notes: Optional[str] = None
     seen_count: int
     typed_correct_count: int
     spoken_correct_count: int
     hint_count: int = 0
-    status: str
+    status: WordStatus
     mastery_level: int = 0
     next_refresh_at: Optional[datetime] = None
-    word_category: Optional[str] = None
+    word_category: Optional[Literal["high_frequency", "encounter"]] = None
     frequency_rank: Optional[int] = None
 
     class Config:
         from_attributes = True
+
+
+class UnknownWordSchema(BaseModel):
+    # Mirrors UserWordSchema's dual id/word_id so unknown/known words share a shape
+    # on the FE side.
+    id: str
+    word_id: str
+    spanish: str
+    english: str
+    word_category: Optional[Literal["high_frequency", "encounter"]] = None
+    frequency_rank: Optional[int] = None
+
+
+class UnknownWordsResponse(BaseModel):
+    high_frequency: List[UnknownWordSchema]
+    encounter: List[UnknownWordSchema]
 
 
 class TypedCorrectRequest(BaseModel):
@@ -127,6 +170,20 @@ class TypedCorrectRequest(BaseModel):
 
 class HintRequest(BaseModel):
     word_id: str
+
+
+class HintResponse(BaseModel):
+    hint_count: int
+
+
+class DemoteWordResponse(BaseModel):
+    word_id: str
+    old_level: int
+    new_level: int
+
+
+class MessageOnlyResponse(BaseModel):
+    message: str
 
 
 # Conversation schemas
@@ -164,16 +221,87 @@ class VoiceTurnResponse(BaseModel):
 
 
 # Grammar config schemas
+# drill_config / phase_*_config shapes differ per drill_type (article_matching,
+# conjugation, skip, …). Keep them as free-form dicts but typed as
+# Dict[str, Any] so generated clients see an object-with-unknown-values instead
+# of an empty-shape marker.
 class GrammarConfigResponse(BaseModel):
     situation_type: str
     video_embed_id: Optional[str] = None
     drill_type: Optional[str] = None
     tense: Optional[str] = None
-    phases: dict
-    drill_config: Optional[dict] = None
-    drill_targets: Optional[List[dict]] = None
-    phase_1c_config: Optional[dict] = None
-    phase_2_config: Optional[dict] = None
+    phases: Dict[str, bool]
+    drill_config: Optional[Dict[str, Any]] = Field(default=None, json_schema_extra=_freeform_object_schema)
+    drill_targets: Optional[List[Dict[str, Any]]] = Field(default=None, json_schema_extra=_freeform_object_list_schema)
+    phase_1c_config: Optional[Dict[str, Any]] = Field(default=None, json_schema_extra=_freeform_object_schema)
+    phase_2_config: Optional[Dict[str, Any]] = Field(default=None, json_schema_extra=_freeform_object_schema)
+
+
+# Grammar gate / completion schemas
+class GrammarGate(BaseModel):
+    grammar_level: float
+    situation_id: Optional[str] = None
+    title: str
+    vl_threshold: int
+    has_content: bool
+    total_lessons: Optional[int] = None
+    resume_phase: Optional[Literal["learn", "voice-chat"]] = None
+
+
+class GrammarGatesResponse(BaseModel):
+    vocab_level: int
+    grammar_level: float
+    is_gated: bool
+    gate: Optional[GrammarGate] = None
+
+
+class GrammarUnit(BaseModel):
+    grammar_level: float
+    title: str
+    vl_threshold: int
+    has_content: bool
+    completed: bool
+    total_lessons: int
+    completed_lessons: int
+
+
+class GrammarCompletedResponse(BaseModel):
+    grammar_units: List[GrammarUnit]
+
+
+# Daily usage schemas
+class DailyUsageResponse(BaseModel):
+    encounters_used: int
+    encounters_limit: int
+    encounters_remaining: int
+
+
+# Onboarding schemas
+class AvailableCategory(BaseModel):
+    id: str
+    name: str
+    description: str
+
+
+class AvailableCategoriesResponse(BaseModel):
+    categories: List[AvailableCategory]
+
+
+class UpdateAnimationTypesResponse(BaseModel):
+    selected_animation_types: List[str]
+
+
+# Auth schemas (reset)
+class ResetProgressResponse(BaseModel):
+    reset: bool
+    deleted_words: int
+    deleted_situations: int
+    deleted_conversations: int
+
+
+class ResetPasswordResponse(BaseModel):
+    reset: bool
+    email: str
 
 
 # Refresh (SRS) schemas


### PR DESCRIPTION
## Summary
Unblocks the last deferred item of Spanish-for-Expats_FE issue #9 (Phase 6 TanStack Query cleanup): migrating `lib/types.ts` to re-export directly from the generated OpenAPI schema. Today several FE types can't come from codegen because the backend either has no `response_model` on the endpoint or uses a plain `dict` whose shape doesn't survive to OpenAPI.

### What the FE saw before

- `/v1/situations/daily-usage`, `/v1/situations/grammar-completed`, `/v1/situations/grammar-gates`, `/v1/user/words/unknown`, `/v1/onboarding/available-categories`, `/v1/auth/reset-progress` — all typed as `unknown` in the generated client.
- `GrammarConfigResponse.phases` / `drill_config` / `drill_targets` / `phase_1c_config` / `phase_2_config` — typed as `Record<string, never>` (i.e. an empty object forever).
- `UserWordSchema.status: str` — a plain string instead of the `'learning' | 'mastered'` union the FE uses everywhere.
- `UserWordSchema` had no `id` field, so FE `Word`-based types had to manually remap `word_id → id`.

### What the FE sees now (verified by running `openapi-typescript` against the local `app.openapi()` output)

- Every endpoint above has a concrete `$ref` to a typed response model.
- `phases: { [key: string]: boolean }`.
- `drill_config?: { [key: string]: unknown } | null` (and sibling fields likewise), via `json_schema_extra` helpers in `app/schemas.py` that inject `additionalProperties: true` inside the anyOf object variant — Pydantic 2 otherwise emits `{type: object}` which openapi-typescript treats as `Record<string, never>`.
- `UserWordSchema.status: 'learning' | 'mastered'` (backed by the existing `ck_user_words_status` CheckConstraint).
- `UserWordSchema` now has both `id` (new) and `word_id` (unchanged) pointing to the same value — existing consumers keep working, new FE consumers can read `.id` directly.
- `UserWordSchema.notes` is populated from the underlying `Word.notes` column.

### Response models wired

| Endpoint | Response model |
|---|---|
| `GET /v1/situations/daily-usage` | `DailyUsageResponse` |
| `GET /v1/situations/grammar-gates` | `GrammarGatesResponse` |
| `GET /v1/situations/grammar-completed` | `GrammarCompletedResponse` |
| `GET /v1/user/words/unknown` | `UnknownWordsResponse` |
| `GET /v1/onboarding/available-categories` | `AvailableCategoriesResponse` |
| `PATCH /v1/onboarding/animation-types` | `UpdateAnimationTypesResponse` |
| `POST /v1/auth/reset-progress` | `ResetProgressResponse` |
| `POST /v1/auth/admin-reset-password` | `ResetPasswordResponse` |
| `POST /v1/user/words/typed-correct` | `MessageOnlyResponse` |
| `POST /v1/user/words/hint` | `HintResponse` |
| `POST /v1/user/words/demote` | `DemoteWordResponse` |

## Backwards compatibility
- All existing fields are preserved (including `word_id`). Only additive changes + tightening of types that already matched real values (status enum, category enum).
- Response body shapes for the newly-typed endpoints are identical to what the raw-dict versions returned.

## Test plan
- [x] `from app.main import app; app.openapi()` succeeds — verified locally.
- [x] `pytest --collect-only` collects 171 tests without import errors.
- [x] Regenerated schema via `openapi-typescript` and inspected the relevant type definitions (`GrammarConfigResponse`, `UserWordSchema`, `UnknownWordsResponse`, etc.) — all correct.
- [ ] CI runs the full pytest suite against QA Postgres.
- [ ] After deploy to QA, FE's `pnpm codegen:api` will pick up the new schema — the FE follow-up will re-export from it and drop `lib/types.ts`.

## Out of scope
- Migrating the FE `lib/types.ts` → `lib/api/types.ts` re-exports. Separate FE PR against the FE `qa` branch once this is deployed.