### PR TITLE
Fix 500 on /v1/user/words/unknown when grammar words exist

### DIFF
--- a/app/api/v1/user_words.py
+++ b/app/api/v1/user_words.py
@@ -165,20 +165,21 @@ async def get_unknown_words(
         ~Word.id.in_(learned_word_ids) if learned_word_ids else True
     )
     
-    # Filter by category if provided
+    # Filter by category if provided. Grammar-verb rows (word_category="grammar")
+    # are intentionally excluded — they're learned through grammar lessons, not
+    # the word-bank flow, so they don't belong in either bucket.
     if category:
         query = query.filter(Word.word_category == category)
     else:
-        # Only return words with a category (high_frequency or encounter)
-        query = query.filter(Word.word_category.isnot(None))
-    
+        query = query.filter(Word.word_category.in_(['high_frequency', 'encounter']))
+
     unknown_words = query.order_by(Word.frequency_rank.asc().nullslast(), Word.spanish.asc()).all()
     unknown_words = apply_alt_language(unknown_words, current_user.alt_language, db)
 
     # Group by category
     high_frequency = []
     encounter = []
-    
+
     for word in unknown_words:
         word_data = UnknownWordSchema(
             id=word.id,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -141,7 +141,10 @@ class UserWordSchema(BaseModel):
     status: WordStatus
     mastery_level: int = 0
     next_refresh_at: Optional[datetime] = None
-    word_category: Optional[Literal["high_frequency", "encounter"]] = None
+    # Grammar-verb rows (hablar/beber/…) legitimately have word_category="grammar"
+    # because users track progress on them through grammar lessons. Keep it in
+    # the union so UserWord rows pointing at those verbs don't blow up serialization.
+    word_category: Optional[Literal["high_frequency", "encounter", "grammar"]] = None
     frequency_rank: Optional[int] = None
 
     class Config:


### PR DESCRIPTION
## Summary
Railway traceback from QA:
\`\`\`
File \"/app/app/api/v1/user_words.py\", line 183, in get_unknown_words
    word_data = UnknownWordSchema(
ValidationError: 1 validation error for UnknownWordSchema
word_category
  Input should be 'high_frequency' or 'encounter'
  [type=literal_error, input_value='grammar', input_type=str]
\`\`\`

The response-model work in #3 tightened \`word_category\` to a Literal over \`'high_frequency' | 'encounter'\`, but the Word table also carries \`word_category=\"grammar\"\` for the grammar-verb rows seeded by \`migrate_grammar_prod.py\` and \`seed_qa.py\`. Two call sites hit that Literal and 500'd:

1. **\`GET /v1/user/words/unknown\`** — its SQL filter used \`word_category IS NOT NULL\`, so grammar rows flowed into the loop and tripped Pydantic before the subsequent \`if/elif\` could skip them.
2. **\`GET /v1/user/words\`** — any user with completed grammar lessons owns UserWord rows pointing at \`word_category=\"grammar\"\` words, same validation error.

## Fix
- \`/unknown\`: tightened the SQL filter to \`word_category IN ('high_frequency', 'encounter')\`. Matches the endpoint's documented intent (only those two buckets are returned) and the loop's actual behavior.
- \`UserWordSchema\`: widened the Literal to \`'high_frequency' | 'encounter' | 'grammar'\`. Users legitimately track progress on grammar verbs through grammar lessons, so the value does appear on the wire.
- \`UnknownWordSchema\` stays narrow on purpose — grammar rows never reach it now.

## Verified
- Pydantic accepts all three values (\`high_frequency\`, \`encounter\`, \`grammar\`) + \`None\` for UserWordSchema; still rejects \`'grammar'\` for UnknownWordSchema (never supplied with one now).
- OpenAPI schema preview: UserWordSchema.word_category is \`enum: [high_frequency, encounter, grammar] | null\`; UnknownWordSchema.word_category unchanged.

## Test plan
- [ ] CI full pytest suite
- [ ] After deploy to QA: rerun the failing \`/v1/user/words/unknown\` curl with the same token — expect 200 with \`{ high_frequency: [...], encounter: [...] }\`
- [ ] \`/v1/user/words\` for a user who's completed any grammar lesson now returns 200 instead of 500

## FE follow-up
The widened Literal changes the generated TS type for \`ApiUserWord.word_category\`. Once this merges + deploys, FE PR #24's committed \`lib/api/schema.d.ts\` will drift. I'll push a commit to #24 to bump the schema.