### PR TITLE
Add user_reports table + POST /v1/reports endpoint (#5)

### DIFF
--- a/app/api/v1/reports.py
+++ b/app/api/v1/reports.py
@@ -1,0 +1,80 @@
+import logging
+
+from fastapi import APIRouter, BackgroundTasks, Depends, status
+from sqlalchemy.orm import Session
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import User, UserReport
+from app.schemas import UserReportCreate, UserReportResponse
+from app.services.email_service import send_report_notification
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+def _safe_notify(report, reporter_email, recipients):
+    """Call send_report_notification and swallow any exception.
+
+    Defense-in-depth: send_report_notification is already expected to return
+    False on failure rather than raise, but background tasks must never
+    surface errors back to the client, so we guard here too.
+    """
+    try:
+        send_report_notification(report, reporter_email, recipients)
+    except Exception as e:
+        logger.error(
+            f"[Reports] Admin notification task raised for report {report.id}: {e}"
+        )
+
+
+@router.post(
+    "",
+    response_model=UserReportResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_report(
+    payload: UserReportCreate,
+    background_tasks: BackgroundTasks,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> UserReportResponse:
+    """Persist a user-submitted report and notify admins asynchronously.
+
+    The 201 response does not wait on SMTP — admin notification runs as a
+    background task and must not fail the request if Gmail is misconfigured
+    or unreachable.
+    """
+    report = UserReport(
+        user_id=current_user.id,
+        category=payload.category,
+        description=payload.description,
+        context=payload.context,
+    )
+    db.add(report)
+    db.commit()
+    db.refresh(report)
+
+    admin_emails = [
+        email
+        for (email,) in db.query(User.email).filter(User.is_admin.is_(True)).all()
+        if email
+    ]
+
+    if not admin_emails:
+        logger.warning(
+            f"[Reports] No admin users configured; skipping email for report {report.id}"
+        )
+    else:
+        logger.info(
+            f"[Reports] Scheduling admin notification for report {report.id} "
+            f"to {len(admin_emails)} admin(s)"
+        )
+        background_tasks.add_task(
+            _safe_notify,
+            report,
+            current_user.email,
+            admin_emails,
+        )
+
+    return report

--- a/app/main.py
+++ b/app/main.py
@@ -40,7 +40,7 @@ except Exception as e:
     # If logging fails, at least print to stdout
     print(f"⚠️  Failed to emit boot event: {e}", file=sys.stderr)
 
-from app.api.v1 import auth, subscription, situations, user_words, conversations, onboarding, logs, refreshes, translate, tts
+from app.api.v1 import auth, subscription, situations, user_words, conversations, onboarding, logs, refreshes, translate, tts, reports
 from app.database import engine
 from app.models import Base
 
@@ -297,6 +297,8 @@ logger.info("  ✅ /v1/tts (GET /word - per-word pronunciation)")
 from app.api.v1 import tutor
 app.include_router(tutor.router, prefix="/v1/tutor", tags=["tutor"])
 logger.info("  ✅ /v1/tutor (GET /student - tutor dashboard)")
+app.include_router(reports.router, prefix="/v1/reports", tags=["reports"])
+logger.info("  ✅ /v1/reports (POST / - user-submitted reports)")
 logger.info("✅ All routes registered")
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -27,6 +27,7 @@ class User(Base):
     user_words = relationship("UserWord", back_populates="user")
     user_situations = relationship("UserSituation", back_populates="user")
     conversations = relationship("Conversation", back_populates="user")
+    reports = relationship("UserReport", back_populates="user")
 
 
 class Subscription(Base):
@@ -149,6 +150,45 @@ class Conversation(Base):
     # Relationships
     user = relationship("User", back_populates="conversations")
     situation = relationship("Situation", back_populates="conversations")
+
+
+# Single source of truth for the category/status closed sets used by the
+# Pydantic schemas and the CHECK constraints in migration 016.
+REPORT_CATEGORIES = (
+    'platform', 'translation', 'pronunciation',
+    'voice_chat', 'subscription', 'suggestion', 'other',
+)
+REPORT_STATUSES = ('new', 'investigating', 'resolved', 'dismissed')
+
+
+class UserReport(Base):
+    __tablename__ = "user_reports"
+    __table_args__ = (
+        CheckConstraint(
+            "category IN ('" + "','".join(REPORT_CATEGORIES) + "')",
+            name="ck_user_reports_category",
+        ),
+        CheckConstraint(
+            "status IN ('" + "','".join(REPORT_STATUSES) + "')",
+            name="ck_user_reports_status",
+        ),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    category = Column(String(32), nullable=False)
+    description = Column(Text, nullable=False)
+    context = Column(JSONB, nullable=False, default=dict, server_default="{}")
+    status = Column(String(16), nullable=False, default="new", server_default="new", index=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), index=True)
+    resolved_at = Column(DateTime(timezone=True), nullable=True)
+
+    user = relationship("User", back_populates="reports")
 
 
 class DailyEncounterLog(Base):

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -24,6 +24,9 @@ UserSituation = models_legacy.UserSituation
 Conversation = models_legacy.Conversation
 Subscription = models_legacy.Subscription
 DailyEncounterLog = models_legacy.DailyEncounterLog
+UserReport = models_legacy.UserReport
+REPORT_CATEGORIES = models_legacy.REPORT_CATEGORIES
+REPORT_STATUSES = models_legacy.REPORT_STATUSES
 # Base is imported from database, not from models.py
 from app.database import Base
 
@@ -44,6 +47,9 @@ __all__ = [
     "Conversation",
     "Subscription",
     "DailyEncounterLog",
+    "UserReport",
+    "REPORT_CATEGORIES",
+    "REPORT_STATUSES",
     "LLMRequest",
     "STTRequest",
     "TTSRequest",

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -334,3 +334,31 @@ class ErrorResponse(BaseModel):
     error: str
 
 
+# User reports
+ReportCategory = Literal[
+    'platform', 'translation', 'pronunciation',
+    'voice_chat', 'subscription', 'suggestion', 'other',
+]
+ReportStatus = Literal['new', 'investigating', 'resolved', 'dismissed']
+
+
+class UserReportCreate(BaseModel):
+    category: ReportCategory
+    description: str = Field(min_length=10, max_length=2000)
+    context: Dict[str, Any] = Field(
+        default_factory=dict,
+        json_schema_extra=_freeform_object_schema,
+    )
+
+
+class UserReportResponse(BaseModel):
+    id: UUID
+    category: ReportCategory
+    description: str
+    status: ReportStatus
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -2,10 +2,16 @@
 
 import smtplib
 import logging
+import json
+from html import escape
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from typing import TYPE_CHECKING, Optional
 
 from app.config import settings
+
+if TYPE_CHECKING:
+    from app.models import UserReport
 
 logger = logging.getLogger(__name__)
 
@@ -51,4 +57,80 @@ def send_reset_email(to_email: str, reset_url: str) -> bool:
         return True
     except Exception as e:
         logger.error(f"[Email] Failed to send to {to_email}: {e}")
+        return False
+
+
+def send_report_notification(
+    report: "UserReport",
+    reporter_email: Optional[str],
+    recipients: list[str],
+) -> bool:
+    """Notify admins about a newly submitted user report.
+
+    Must never raise: it runs in a FastAPI BackgroundTasks context and
+    SMTP failures should not surface to the client. Returns True on success.
+    """
+    if not recipients:
+        logger.warning(f"[Email] No recipients for report {report.id}, skipping")
+        return False
+
+    if not settings.smtp_email or not settings.smtp_app_password:
+        logger.error(
+            f"[Email] SMTP not configured; cannot notify admins about report {report.id}"
+        )
+        return False
+
+    try:
+        description_preview = (report.description or "")[:60]
+        subject = f"[SFE Report] {report.category} — {description_preview}"
+
+        reporter_label = reporter_email or "anonymous"
+        context_json = json.dumps(report.context or {}, indent=2, default=str, sort_keys=True)
+        created_at_iso = report.created_at.isoformat() if report.created_at else ""
+
+        text_body = (
+            f"New user report\n"
+            f"ID: {report.id}\n"
+            f"Category: {report.category}\n"
+            f"Status: {report.status}\n"
+            f"Created: {created_at_iso}\n"
+            f"Reporter: {reporter_label}\n\n"
+            f"Description:\n{report.description}\n\n"
+            f"Context:\n{context_json}\n"
+        )
+
+        html_body = f"""
+        <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
+            <h2 style="color: #28968C;">New User Report</h2>
+            <p><strong>ID:</strong> {escape(str(report.id))}<br>
+               <strong>Category:</strong> {escape(report.category)}<br>
+               <strong>Status:</strong> {escape(report.status)}<br>
+               <strong>Created:</strong> {escape(created_at_iso)}<br>
+               <strong>Reporter:</strong> {escape(reporter_label)}</p>
+            <h3 style="color: #28968C; font-size: 14px; margin-top: 20px;">Description</h3>
+            <p style="white-space: pre-wrap;">{escape(report.description or "")}</p>
+            <h3 style="color: #28968C; font-size: 14px; margin-top: 20px;">Context</h3>
+            <pre style="background: #f5f5f5; padding: 12px; border-radius: 6px;
+                        font-size: 12px; overflow-x: auto;">{escape(context_json)}</pre>
+            <p style="color: #999; font-size: 12px;">— Spanish for Expats</p>
+        </div>
+        """
+
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = subject
+        msg["From"] = f"Spanish for Expats <{settings.smtp_email}>"
+        msg["To"] = ", ".join(recipients)
+        msg.attach(MIMEText(text_body, "plain"))
+        msg.attach(MIMEText(html_body, "html"))
+
+        with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as server:
+            server.starttls()
+            server.login(settings.smtp_email, settings.smtp_app_password)
+            server.send_message(msg)
+        logger.info(
+            f"[Email] Report notification sent for report {report.id} to {len(recipients)} admin(s)"
+        )
+        return True
+    except Exception as e:
+        logger.error(f"[Email] Failed to send report notification for report {report.id}: {e}")
         return False

--- a/migrations/versions/016_add_user_reports.py
+++ b/migrations/versions/016_add_user_reports.py
@@ -1,0 +1,60 @@
+"""Add user_reports table
+
+Revision ID: 016_user_reports
+Revises: 015_swedish_alt_language
+Create Date: 2026-04-20 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+# revision identifiers, used by Alembic.
+revision = '016_user_reports'
+down_revision = '015_swedish_alt_language'
+branch_labels = None
+depends_on = None
+
+
+CATEGORY_VALUES = (
+    'platform', 'translation', 'pronunciation',
+    'voice_chat', 'subscription', 'suggestion', 'other',
+)
+STATUS_VALUES = ('new', 'investigating', 'resolved', 'dismissed')
+
+
+def upgrade() -> None:
+    op.create_table(
+        'user_reports',
+        sa.Column('id', UUID(as_uuid=True), nullable=False),
+        sa.Column('user_id', UUID(as_uuid=True), sa.ForeignKey('users.id', ondelete='SET NULL'), nullable=True),
+        sa.Column('category', sa.String(length=32), nullable=False),
+        sa.Column('description', sa.Text(), nullable=False),
+        sa.Column('context', JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+        sa.Column('status', sa.String(length=16), server_default=sa.text("'new'"), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('resolved_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.CheckConstraint(
+            "category IN ('" + "','".join(CATEGORY_VALUES) + "')",
+            name='ck_user_reports_category',
+        ),
+        sa.CheckConstraint(
+            "status IN ('" + "','".join(STATUS_VALUES) + "')",
+            name='ck_user_reports_status',
+        ),
+    )
+    op.create_index('ix_user_reports_user_id', 'user_reports', ['user_id'])
+    op.create_index('ix_user_reports_status', 'user_reports', ['status'])
+    op.create_index(
+        'ix_user_reports_created_at',
+        'user_reports',
+        [sa.text('created_at DESC')],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_user_reports_created_at', table_name='user_reports')
+    op.drop_index('ix_user_reports_status', table_name='user_reports')
+    op.drop_index('ix_user_reports_user_id', table_name='user_reports')
+    op.drop_table('user_reports')

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,149 @@
+import logging
+from uuid import UUID
+
+import pytest
+
+from app.models import User, UserReport
+from tests.conftest import register_user
+
+
+@pytest.fixture
+def admin_user(db):
+    """Seed an is_admin=True user directly in the DB (no need to log them in)."""
+    from app.auth import get_password_hash
+    user = User(
+        email="admin@example.com",
+        password_hash=get_password_hash("adminpassword123"),
+        is_admin=True,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _scheduled_calls(background_scheduler):
+    """Convenience: snapshot the list of scheduled background task callables."""
+    return list(background_scheduler.calls)
+
+
+class _FakeScheduler:
+    """Captures BackgroundTasks scheduled calls without actually running them."""
+
+    def __init__(self):
+        self.calls = []
+
+    def install(self, monkeypatch):
+        from fastapi import BackgroundTasks
+
+        real_add = BackgroundTasks.add_task
+
+        def capture(self_bt, func, *args, **kwargs):
+            _FakeScheduler._store.calls.append((func, args, kwargs))
+            return real_add(self_bt, func, *args, **kwargs)
+
+        _FakeScheduler._store = self
+        monkeypatch.setattr(BackgroundTasks, "add_task", capture)
+
+
+def _valid_body(**overrides):
+    body = {
+        "category": "platform",
+        "description": "The start button on the lesson screen does nothing when I tap it.",
+        "context": {"route": "/lesson/1", "situation_id": "bank_open_1"},
+    }
+    body.update(overrides)
+    return body
+
+
+def test_create_report_happy_path(client, db, auth_user, admin_user, monkeypatch):
+    _, headers = auth_user
+
+    scheduler = _FakeScheduler()
+    scheduler.install(monkeypatch)
+    # Prevent the captured background task from actually hitting SMTP.
+    monkeypatch.setattr(
+        "app.api.v1.reports.send_report_notification",
+        lambda *args, **kwargs: True,
+    )
+
+    resp = client.post("/v1/reports", json=_valid_body(), headers=headers)
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["category"] == "platform"
+    assert body["status"] == "new"
+    assert body["description"].startswith("The start button")
+    report_id = UUID(body["id"])
+
+    row = db.query(UserReport).filter(UserReport.id == report_id).one()
+    assert row.category == "platform"
+    assert row.context == {"route": "/lesson/1", "situation_id": "bank_open_1"}
+    assert row.user_id is not None
+
+    assert len(scheduler.calls) == 1
+    _, args, _ = scheduler.calls[0]
+    scheduled_report, scheduled_reporter_email, scheduled_recipients = args
+    assert scheduled_report.id == report_id
+    assert scheduled_reporter_email == "test@example.com"
+    assert scheduled_recipients == ["admin@example.com"]
+
+
+def test_create_report_description_too_short(client, auth_user):
+    _, headers = auth_user
+    resp = client.post(
+        "/v1/reports",
+        json=_valid_body(description="too short"),
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_create_report_invalid_category(client, auth_user):
+    _, headers = auth_user
+    resp = client.post(
+        "/v1/reports",
+        json=_valid_body(category="not_a_real_category"),
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_create_report_requires_auth_invalid_token(client):
+    resp = client.post(
+        "/v1/reports",
+        json=_valid_body(),
+        headers={"Authorization": "Bearer not-a-real-jwt"},
+    )
+    assert resp.status_code == 401
+
+
+def test_create_report_no_admins_skips_scheduling(client, db, auth_user, monkeypatch, caplog):
+    """With zero is_admin=True users, the background task must not be scheduled."""
+    _, headers = auth_user
+
+    scheduler = _FakeScheduler()
+    scheduler.install(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="app.api.v1.reports"):
+        resp = client.post("/v1/reports", json=_valid_body(), headers=headers)
+
+    assert resp.status_code == 201
+    assert len(scheduler.calls) == 0
+    assert any("No admin users configured" in rec.message for rec in caplog.records)
+
+
+def test_create_report_notification_failure_does_not_fail_request(
+    client, auth_user, admin_user, monkeypatch
+):
+    """If send_report_notification raises, the 201 response must still succeed."""
+    _, headers = auth_user
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("SMTP is on fire")
+
+    monkeypatch.setattr("app.api.v1.reports.send_report_notification", boom)
+
+    resp = client.post("/v1/reports", json=_valid_body(), headers=headers)
+    # The background task runs AFTER the response is sent, so the status must
+    # still be 201 regardless of what send_report_notification does.
+    assert resp.status_code == 201


### PR DESCRIPTION
Closes #5.

## Summary
- New `user_reports` table (Alembic 016) with UUID PK, nullable `user_id` (`ON DELETE SET NULL`), JSONB `context`, CHECK constraints on `category` and `status`, and indexes on `user_id`, `status`, `created_at DESC`.
- `POST /v1/reports` with typed `UserReportCreate` / `UserReportResponse` (`response_model`, 201) so FE can pick the types up via `openapi-typescript`.
- Admin notification email via the existing Gmail SMTP plumbing (`send_report_notification` in `email_service.py`), dispatched via `BackgroundTasks` wrapped in a defensive `_safe_notify` so SMTP/Gmail outages can never fail the 201 response.
- `context` keeps the `additionalProperties: true` shape (BE PR #3 pattern) so generated clients see a real open object.
- Category + status constants live once in `app/models.py` and are shared by the Pydantic literals and the CHECK constraints.

## Non-goals (per issue)
- No admin triage endpoints — triage via direct DB queries for now.
- No anonymous reports for v1 — endpoint requires auth (column nullable for future use).
- No attachments.

## Test plan
- [x] `alembic upgrade head` on a fresh DB creates the table + indexes + CHECK constraints.
- [x] `alembic downgrade -1` drops the table cleanly (verified via `to_regclass('user_reports') IS NULL`).
- [x] New `tests/test_reports.py` covers: happy path (201 + DB row + scheduled task args), `description < 10` → 422, invalid category → 422, invalid JWT → 401, zero admins skips scheduling + logs warning, raising notification callable still returns 201.
- [x] Full suite: **177 passed**.
- [x] `/openapi.json` exposes the new endpoint; `context` schema has `additionalProperties: true` (no `false` regression).
- [ ] Smoke test in QA after deploy: submit a report from an authed account, verify the row lands, the email reaches every `is_admin=true` user, and SMTP downtime does not break `POST /v1/reports`.