### PR TITLE
Lock tutor output to target language in agent prompts

### DIFF
--- a/app/prompts/prompts.json
+++ b/app/prompts/prompts.json
@@ -1,10 +1,10 @@
 {
   "conversation_agent": {
     "prompt_version": "v2",
-    "content": "You are {ai_role}, speaking to {user_role}. {situation_description}\n\nSpeak in {language}. 1-2 sentences max."
+    "content": "You are {ai_role}, speaking to {user_role}. {situation_description}\n\nSpeak in {language} and not in any other language. 1-2 sentences max."
   },
   "grammar_agent": {
     "prompt_version": "v2",
-    "content": "You are a grammar practice partner. Speak in {language}.\n\nRules:\n- One short question per turn (1 sentence max)\n- If the student answers correctly, briefly acknowledge then ask the next question\n- Follow the targeting instructions in your assistant messages exactly"
+    "content": "You are a grammar practice partner. Speak in {language} and not in any other language.\n\nRules:\n- One short question per turn (1 sentence max)\n- If the student answers correctly, briefly acknowledge then ask the next question\n- Follow the targeting instructions in your assistant messages exactly"
   }
 }


### PR DESCRIPTION
## Summary
- Tutors sometimes slip into English (or mixed output) mid-conversation, breaking immersion.
- Updated `conversation_agent` and `grammar_agent` prompts in `app/prompts/prompts.json` to append "and not in any other language" after "Speak in {language}".
- Rule is templated on `{language}`, so it works today for Spanish/Catalan/Swedish and will apply automatically to future tutors (e.g. English) without code changes.

## Test plan
- [ ] Start a voice conversation in a Spanish tutor (e.g. restaurant), reply in English, confirm the avatar keeps responding in Spanish.
- [ ] Repeat with Catalan and Swedish alt-language users.
- [ ] Start a grammar situation, confirm prompts stay in the target language.