### PR TITLE
Recast pronoun errors instead of explaining them

### DIFF
--- a/app/prompts/prompts.json
+++ b/app/prompts/prompts.json
@@ -1,10 +1,10 @@
 {
   "conversation_agent": {
     "prompt_version": "v2",
-    "content": "You are {ai_role}, speaking to {user_role}. {situation_description}\n\nSpeak in {language} and not in any other language. 1-2 sentences max."
+    "content": "You are {ai_role}, speaking to {user_role}. {situation_description}\n\nSpeak in {language} and not in any other language. Always use correct pronouns — if the student uses the wrong one, recast with the correct pronoun in your reply without explaining the mistake. 1-2 sentences max."
   },
   "grammar_agent": {
     "prompt_version": "v2",
-    "content": "You are a grammar practice partner. Speak in {language} and not in any other language.\n\nRules:\n- One short question per turn (1 sentence max)\n- If the student answers correctly, briefly acknowledge then ask the next question\n- Follow the targeting instructions in your assistant messages exactly"
+    "content": "You are a grammar practice partner. Speak in {language} and not in any other language.\n\nRules:\n- One short question per turn (1 sentence max)\n- If the student answers correctly, briefly acknowledge then ask the next question\n- If the student uses the wrong pronoun, recast with the correct one instead of explaining — model the form, don't teach it\n- Follow the targeting instructions in your assistant messages exactly"
   }
 }


### PR DESCRIPTION
## Summary
- Adds a recasting rule to both `conversation_agent` and `grammar_agent` prompts: when the student uses an incorrect pronoun, the tutor replies using the correct one instead of stopping to explain.
- Recasting is a standard language-teaching technique — it models the correct form implicitly and keeps the conversation flowing.
- Applies to all current and future tutor languages (Spanish, Catalan, Swedish, English) since the rule is in the shared template.

## Test plan
- [ ] Spanish tutor: say "¿tú tienes hambre?" when usted is expected — confirm the tutor responds with "usted" naturally, no explanation.
- [ ] Grammar situation with `drill_targets`: give the wrong pronoun, confirm the tutor recasts without breaking the drill flow.
- [ ] Baseline check: use the correct pronoun — tutor should not mention pronouns at all.