### PR TITLE
Phase 1: extract shared Realtime session-config builder

### DIFF
--- a/app/api/v1/conversations.py
+++ b/app/api/v1/conversations.py
@@ -15,6 +15,8 @@ from app.schemas import (
     CreateConversationResponse,
     MessageRequest,
     MessageResponse,
+    RealtimeTurnRequest,
+    RealtimeTurnResponse,
     VoiceTurnResponse,
     WordSchema
 )
@@ -29,7 +31,17 @@ from app.services.conversation_service import (
 )
 from app.services.encounter_messages import get_initial_message_for_encounter
 from app.api.v1.situations import get_vocab_level, get_grammar_level
-from app.services.voice_turn_service import build_transcription_prompt, build_conversation_prompt, build_grammar_system_prompt, build_grammar_user_prompt, get_language_mode, get_conversation_system_prompt, build_system_prompt
+from app.services.voice_turn_service import (
+    build_transcription_prompt,
+    build_conversation_prompt,
+    build_grammar_system_prompt,
+    build_grammar_user_prompt,
+    get_language_mode,
+    get_conversation_system_prompt,
+    build_system_prompt,
+    check_completion,
+    persist_turn,
+)
 from app.data.grammar_situations import get_grammar_config
 from app.services.alt_language_service import apply_alt_language, get_target_language_name
 from app.utils.audio import generate_audio_filename, get_audio_path, get_audio_url, upload_to_r2
@@ -815,35 +827,17 @@ async def voice_turn_transcribe(
     if stt_time > 2.0:
         logger.warning(f"[Voice Turn] STT exceeded 2s threshold: {stt_time:.2f}s")
 
-    # Grammar situations: match conjugated forms from drill_config
-    grammar_config = get_grammar_config(conversation.situation_id)
-    if grammar_config and grammar_config.get("drill_config", {}).get("answers"):
-        from app.services.word_detection import detect_grammar_words_in_text
-        detected_word_ids = detect_grammar_words_in_text(
-            user_transcript, words, grammar_config["drill_config"]["answers"]
-        )
-    else:
-        detected_word_ids = detect_words_in_text(user_transcript, words)
-    was_empty = len(conversation.used_spoken_word_ids or []) == 0
-    current_used = set(conversation.used_spoken_word_ids or [])
-    current_used.update(detected_word_ids)
-    conversation.used_spoken_word_ids = list(current_used)
-    update_user_word_stats(db, str(current_user.id), detected_word_ids, "voice")
-
-    if was_empty and detected_word_ids and conversation.conversation_type == "lesson":
-        target_set = set(conversation.target_word_ids or [])
-        if any(w in target_set for w in detected_word_ids):
-            db.execute(
-                pg_insert(UserMilestoneEvent)
-                .values(
-                    user_id=current_user.id,
-                    milestone_key="first_word",
-                    situation_id=conversation.situation_id,
-                    conversation_id=conversation.id,
-                )
-                .on_conflict_do_nothing(constraint="uq_user_milestone_situation")
-            )
-
+    # Shared with /realtime-turn: detects words (grammar-aware when applicable),
+    # extends used_spoken_word_ids, upserts user_words counters, records the
+    # first_word milestone, and increments turn_count.
+    _, detected_word_ids = persist_turn(
+        db=db,
+        conversation=conversation,
+        user_id=current_user.id,
+        user_transcript=user_transcript,
+        assistant_text="",
+        alt_language=alt_language,
+    )
     missing_word_ids = get_missing_word_ids(conversation, "voice")
     db.commit()
 
@@ -1053,10 +1047,11 @@ async def voice_turn_respond(
                 elif event["type"] == "done":
                     # Refresh conversation from DB to ensure we have latest used_spoken_word_ids
                     db.refresh(conversation)
-                    conv_complete = check_conversation_complete(conversation, "voice")
+                    conv_complete, _ = check_completion(conversation)
                     logger.info(
                         f"[Voice Turn] Completion check: target={conversation.target_word_ids}, "
-                        f"spoken={conversation.used_spoken_word_ids}, complete={conv_complete}"
+                        f"spoken={conversation.used_spoken_word_ids}, turns={conversation.turn_count}, "
+                        f"complete={conv_complete}"
                     )
                     if conv_complete:
                         conversation.status = "complete"
@@ -1076,3 +1071,72 @@ async def voice_turn_respond(
             yield json_module.dumps({"type": "error", "message": str(e)}) + "\n"
 
     return StreamingResponse(generate_stream(), media_type="application/x-ndjson")
+
+
+@router.post(
+    "/{conversation_id}/realtime-turn",
+    response_model=RealtimeTurnResponse,
+)
+async def realtime_turn(
+    conversation_id: str,
+    body: RealtimeTurnRequest,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Ingest one completed realtime-voice turn.
+
+    The browser streams audio directly to OpenAI over WebRTC (see
+    `POST /v1/realtime/sessions`), so the backend doesn't see the audio or
+    control endpointing. After each turn the FE POSTs the finalized
+    transcripts here so we can:
+      - run deterministic word detection against the conversation's targets,
+      - extend `used_spoken_word_ids` and bump mastery counters,
+      - increment `turn_count` and enforce the 30-turn hard limit,
+      - record the `first_word` milestone for new lesson conversations,
+      - report back the current state so the FE can update chips,
+        countdowns, and close the peer connection on completion.
+
+    Parity note: the word detection, persistence, and completion logic are
+    the same helpers `/voice-turn` calls — splitting by flow would be a
+    parity bug waiting to happen.
+    """
+    request.state.user_id = current_user.id
+
+    conversation = db.query(Conversation).filter(
+        Conversation.id == conversation_id,
+        Conversation.user_id == current_user.id,
+    ).first()
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found"
+        )
+    if conversation.mode != "voice":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This endpoint is for voice mode only",
+        )
+
+    _, detected_word_ids = persist_turn(
+        db=db,
+        conversation=conversation,
+        user_id=current_user.id,
+        user_transcript=body.user_transcript,
+        assistant_text=body.assistant_text,
+        alt_language=current_user.alt_language,
+    )
+
+    complete, turns_remaining = check_completion(conversation)
+    if complete and conversation.status != "complete":
+        conversation.status = "complete"
+        conversation.completed_at = datetime.now(timezone.utc)
+
+    db.commit()
+    missing_word_ids = get_missing_word_ids(conversation, "voice")
+
+    return RealtimeTurnResponse(
+        detected_word_ids=detected_word_ids,
+        missing_word_ids=missing_word_ids,
+        conversation_complete=complete,
+        turns_remaining=turns_remaining,
+    )

--- a/app/api/v1/realtime.py
+++ b/app/api/v1/realtime.py
@@ -1,0 +1,60 @@
+"""Realtime voice-chat endpoints.
+
+Owns the ephemeral-token mint used by the FE WebRTC client. The browser trades
+the minted `client_secret` for a direct OpenAI Realtime connection — no audio
+flows through this backend. Word detection, exchange limits, and persistence
+happen server-side via `POST /v1/conversations/{id}/realtime-turn` (Phase 2).
+
+See `app/services/realtime_session_service.py` for the mint flow and backend
+issue #10 for the full phased design.
+"""
+import logging
+
+from fastapi import APIRouter, Depends, Request, status
+from sqlalchemy.orm import Session
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import User
+from app.schemas import RealtimeSessionCreate, RealtimeSessionResponse
+from app.services.realtime_session_service import mint_ephemeral_session
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.post(
+    "/sessions",
+    response_model=RealtimeSessionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_realtime_session(
+    body: RealtimeSessionCreate,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Mint a short-lived OpenAI Realtime client_secret for one Conversation.
+
+    The FE calls this once per conversation (and re-mints when the token is
+    about to expire). The response is safe to embed in the browser — the token
+    can only open a session scoped to the config we built here.
+
+    Errors:
+    - 404 if the conversation doesn't exist.
+    - 403 {error: "FORBIDDEN"} if it belongs to someone else.
+    - 403 {error: "PAYWALL"} if the caller is past the free-tier limit.
+    - 429 if called again for the same conversation within the rate-limit
+      window. Body carries `retry_after_seconds`.
+    - 502 if OpenAI is unreachable or returns an error — the FE should fall
+      back to the legacy `/voice-turn` flow behind its feature flag.
+    """
+    phase = request.headers.get("X-Learning-Phase", "2")
+    request.state.user_id = current_user.id
+
+    return await mint_ephemeral_session(
+        conversation_id=body.conversation_id,
+        current_user=current_user,
+        db=db,
+        phase=phase,
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -40,7 +40,7 @@ except Exception as e:
     # If logging fails, at least print to stdout
     print(f"⚠️  Failed to emit boot event: {e}", file=sys.stderr)
 
-from app.api.v1 import auth, subscription, situations, user_words, conversations, onboarding, logs, refreshes, translate, tts, reports, admin, milestones
+from app.api.v1 import auth, subscription, situations, user_words, conversations, onboarding, logs, refreshes, translate, tts, reports, admin, milestones, realtime
 from app.database import engine
 from app.models import Base
 
@@ -306,6 +306,8 @@ app.include_router(admin.router, prefix="/v1/admin", tags=["admin"])
 logger.info("  ✅ /v1/admin (GET /users, PATCH /users/{id}/plan, GET /freeflow)")
 app.include_router(milestones.router, prefix="/v1/milestones", tags=["milestones"])
 logger.info("  ✅ /v1/milestones (POST / - record phase milestone events)")
+app.include_router(realtime.router, prefix="/v1/realtime", tags=["realtime"])
+logger.info("  ✅ /v1/realtime (POST /sessions - ephemeral OpenAI Realtime tokens)")
 logger.info("✅ All routes registered")
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -151,6 +151,11 @@ class Conversation(Base):
     used_typed_word_ids = Column(JSONB, default=list, nullable=False)
     used_spoken_word_ids = Column(JSONB, default=list, nullable=False)
     status = Column(String, default="active", nullable=False)  # 'active' or 'complete'
+    # Count of persisted user turns. Incremented by voice_turn_service.persist_turn
+    # so the realtime flow (and legacy /voice-turn) can enforce the 30-turn hard
+    # limit in check_completion even when the backend isn't orchestrating each
+    # round-trip. Migration 020 adds it with default 0.
+    turn_count = Column(Integer, default=0, nullable=False, server_default="0")
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
     completed_at = Column(DateTime(timezone=True), nullable=True)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -25,6 +25,7 @@ Conversation = models_legacy.Conversation
 Subscription = models_legacy.Subscription
 DailyEncounterLog = models_legacy.DailyEncounterLog
 UserReport = models_legacy.UserReport
+UserMilestoneEvent = models_legacy.UserMilestoneEvent
 REPORT_CATEGORIES = models_legacy.REPORT_CATEGORIES
 REPORT_STATUSES = models_legacy.REPORT_STATUSES
 # Base is imported from database, not from models.py
@@ -48,6 +49,7 @@ __all__ = [
     "Subscription",
     "DailyEncounterLog",
     "UserReport",
+    "UserMilestoneEvent",
     "REPORT_CATEGORIES",
     "REPORT_STATUSES",
     "LLMRequest",

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -235,6 +235,23 @@ class VoiceTurnResponse(BaseModel):
     conversation_complete: bool
 
 
+# Realtime (WebRTC) session schemas
+# Minted by POST /v1/realtime/sessions — the browser trades this client_secret
+# for a direct OpenAI Realtime WebRTC connection. Backend never relays audio.
+class RealtimeSessionCreate(BaseModel):
+    conversation_id: UUID
+
+
+class RealtimeSessionResponse(BaseModel):
+    client_secret: str
+    # Unix timestamp (seconds) — the ephemeral token is rejected by OpenAI
+    # after this point. Typically ~60s from mint. FE uses it to know when to
+    # re-mint rather than trusting a connection it can no longer refresh.
+    expires_at: int
+    model: str
+    voice: str
+
+
 # Grammar config schemas
 # drill_config / phase_*_config shapes differ per drill_type (article_matching,
 # conjugation, skip, …). Keep them as free-form dicts but typed as

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -252,6 +252,24 @@ class RealtimeSessionResponse(BaseModel):
     voice: str
 
 
+# Post-turn ingestion for the realtime flow. FE calls this after each
+# completed WebRTC turn so the backend can run word detection, update
+# mastery counters, persist state, and enforce the exchange hard limit.
+class RealtimeTurnRequest(BaseModel):
+    user_transcript: str
+    assistant_text: str
+
+
+class RealtimeTurnResponse(BaseModel):
+    detected_word_ids: List[str]
+    missing_word_ids: List[str]
+    conversation_complete: bool
+    # Counts down from EXCHANGE_WARNING_THRESHOLD (25) — FE uses this for the
+    # "N turns left" warning. Pinned to 0 once past the threshold; the hard
+    # limit at 30 is what actually flips `conversation_complete`.
+    turns_remaining: int
+
+
 # Grammar config schemas
 # drill_config / phase_*_config shapes differ per drill_type (article_matching,
 # conjugation, skip, …). Keep them as free-form dicts but typed as

--- a/app/services/realtime_config.py
+++ b/app/services/realtime_config.py
@@ -1,0 +1,219 @@
+"""Shared builder for OpenAI Realtime API session configuration.
+
+Two consumers read from this module:
+
+1. `POST /v1/realtime/sessions` (see `app/services/realtime_session_service.py`)
+   — mints an ephemeral token whose session config is used directly by the
+   browser over WebRTC. The browser streams user audio in and receives assistant
+   audio/text out, so the config carries `turn_detection` (server VAD) and
+   `input_audio_transcription` (Whisper) so OpenAI handles endpointing and gives
+   us per-turn transcripts.
+
+2. `app/services/realtime_service.py` — the legacy server-side WebSocket flow
+   where the backend already has the full `messages` list (system + history +
+   latest user transcript) and just wants OpenAI to run one response turn with
+   streamed PCM16 audio out. It has no user audio input and orchestrates
+   responses itself, so `turn_detection` is disabled and
+   `input_audio_transcription` is omitted.
+
+Both consumers share: model, modalities, voice, system prompt. Keeping that in
+one place is the whole point — if a situation's voice or system prompt drifts
+between the two flows, the user hears/experiences different things depending on
+which code path they hit.
+"""
+from typing import Literal, Optional
+
+from sqlalchemy.orm import Session
+
+from app.data.grammar_situations import get_grammar_config
+from app.models import Conversation, Situation
+from app.services.alt_language_service import get_target_language_name
+from app.services.voice_turn_service import (
+    build_grammar_system_prompt,
+    get_conversation_system_prompt,
+    get_language_mode,
+)
+
+
+REALTIME_MODEL = "gpt-realtime-mini"
+
+# Server VAD params match the FE-expected endpointing behavior. Bumping the
+# threshold makes the model wait longer for silence before closing a turn;
+# lowering it makes barge-in more aggressive. 0.5 / 500ms is OpenAI's default
+# and what the FE's useRealtimeSession hook assumes.
+_DEFAULT_TURN_DETECTION = {
+    "type": "server_vad",
+    "threshold": 0.5,
+    "silence_duration_ms": 500,
+}
+
+# whisper-1 is what the existing `/voice-turn` STT path uses. Keeping the same
+# model means per-turn transcripts from the realtime flow agree with what the
+# legacy flow would have produced for the same audio.
+_DEFAULT_INPUT_TRANSCRIPTION = {"model": "whisper-1"}
+
+
+def resolve_voice(
+    animation_type: str,
+    alt_language: Optional[str] = None,
+) -> tuple[str, Optional[str]]:
+    """Look up (voice, tts_instructions) for this situation's animation type.
+
+    The voice catalog lives in `app/api/v1/conversations.py` to keep it near
+    the legacy `/voice-turn/respond` TTS call that originally owned it. Import
+    here rather than duplicating — if the catalog moves, update this import.
+
+    `tts_instructions` is only meaningful for the legacy server-WS flow (passed
+    to the TTS model as a style directive). The ephemeral/WebRTC flow ignores
+    it because OpenAI Realtime voices don't currently accept per-session TTS
+    instructions the same way.
+    """
+    from app.api.v1.conversations import get_tts_instructions
+
+    return get_tts_instructions(animation_type, alt_language=alt_language)
+
+
+def _resolve_system_prompt(
+    conversation: Conversation,
+    situation: Situation,
+    alt_language: Optional[str],
+    vocab_level: int,
+    grammar_level: float,
+) -> str:
+    """Build the system prompt the model should carry for the whole session.
+
+    Mirrors the logic used by `/voice-turn/respond` for a new turn without any
+    existing message history: pick grammar template if the situation is a
+    grammar drill, otherwise the conversation template. Alt-language mode
+    swaps the language_mode suffix so prompts render in Catalan/Swedish.
+    """
+    language_mode = get_language_mode(
+        situation.encounter_number, vocab_level, grammar_level
+    )
+    if alt_language and language_mode in ("spanish_text", "spanish_audio"):
+        language_mode = language_mode.replace("spanish_", f"{alt_language}_")
+
+    if get_grammar_config(conversation.situation_id):
+        return build_grammar_system_prompt(
+            conversation.situation_id,
+            language_mode=language_mode,
+            alt_language=alt_language,
+        )
+    return get_conversation_system_prompt(
+        language_mode=language_mode,
+        alt_language=alt_language,
+        animation_type=situation.animation_type,
+        situation_id=conversation.situation_id,
+    )
+
+
+def build_session_config(
+    conversation: Conversation,
+    phase: str,
+    db: Session,
+    *,
+    alt_language: Optional[str] = None,
+    vocab_level: int = 0,
+    grammar_level: float = 0.0,
+    mode: Literal["ephemeral", "server_ws"] = "ephemeral",
+) -> dict:
+    """Assemble the Realtime session configuration for a conversation.
+
+    Args:
+        conversation: The Conversation this session is for. Must have
+            `situation_id` populated; the situation is loaded from `db`.
+        phase: Learning phase string ("2", "3", …). Currently informational —
+            carried through for observability and future prompt variants. The
+            FE passes this as the `X-Learning-Phase` header today.
+        db: SQLAlchemy session used to load the Situation row.
+        alt_language: `None` for Spanish, `"catalan"`, or `"swedish"`. Drives
+            both voice TTS accent and the prompt language.
+        vocab_level / grammar_level: used to pick the right
+            `language_mode` for system prompt templating. Callers should pass
+            the same values they'd use in `/voice-turn/respond`.
+        mode:
+            - `"ephemeral"` (default): the config minted into a client_secret
+              for WebRTC. Includes `model`, `input_audio_transcription`, and
+              server-VAD `turn_detection`. This is the dict posted to
+              `POST https://api.openai.com/v1/realtime/sessions`.
+            - `"server_ws"`: the config sent as the `session.update` payload
+              over a server-owned WebSocket. Includes `output_audio_format`
+              `pcm16` (the server re-encodes to MP3) and disables
+              `turn_detection` (the server calls `response.create` itself).
+
+    Returns:
+        A JSON-serializable dict ready to send to OpenAI. Callers don't wrap it
+        — for ephemeral, POST it as the body directly; for server_ws, nest it
+        under `{"type": "session.update", "session": <this>}`.
+    """
+    situation = (
+        db.query(Situation).filter(Situation.id == conversation.situation_id).first()
+    )
+    if not situation:
+        raise ValueError(
+            f"Conversation {conversation.id} references missing situation "
+            f"{conversation.situation_id}"
+        )
+
+    voice, tts_instructions = resolve_voice(
+        situation.animation_type, alt_language=alt_language
+    )
+    system_prompt = _resolve_system_prompt(
+        conversation, situation, alt_language, vocab_level, grammar_level
+    )
+
+    base = {
+        "modalities": ["text", "audio"],
+        "voice": voice,
+        "instructions": system_prompt,
+    }
+
+    if mode == "ephemeral":
+        # The browser connects directly to OpenAI over WebRTC. We need VAD
+        # and Whisper transcription turned on so OpenAI handles endpointing
+        # and gives us per-turn text to forward to `/realtime-turn` for word
+        # detection + persistence.
+        return {
+            "model": REALTIME_MODEL,
+            **base,
+            "input_audio_transcription": dict(_DEFAULT_INPUT_TRANSCRIPTION),
+            "turn_detection": dict(_DEFAULT_TURN_DETECTION),
+        }
+
+    # server_ws: we have the full message list already and want one streamed
+    # response turn out with raw PCM so ffmpeg can re-encode to MP3.
+    return {
+        **base,
+        "output_audio_format": "pcm16",
+        "turn_detection": None,
+    }
+
+
+def build_ws_session_update(
+    voice: str,
+    instructions: str,
+    tts_instructions: Optional[str] = None,
+) -> dict:
+    """Low-level helper for the legacy WS flow in `realtime_service.stream_realtime`.
+
+    That function receives a pre-built `messages` list (system + history +
+    latest user turn) and doesn't load the Conversation, so it can't call
+    `build_session_config` directly. This helper returns the same shape
+    `build_session_config(..., mode="server_ws")` produces from just voice +
+    instructions. Keeping both in this module means the WS payload stays in
+    sync if the schema evolves.
+
+    `tts_instructions`, when provided, is appended to `instructions` as a
+    voice-style directive — matches the pre-refactor inline behavior.
+    """
+    full_instructions = instructions
+    if tts_instructions:
+        full_instructions = f"{instructions}\n\n[Voice style: {tts_instructions}]"
+
+    return {
+        "modalities": ["text", "audio"],
+        "voice": voice,
+        "instructions": full_instructions,
+        "output_audio_format": "pcm16",
+        "turn_detection": None,
+    }

--- a/app/services/realtime_service.py
+++ b/app/services/realtime_service.py
@@ -20,10 +20,10 @@ from typing import Optional
 import websockets
 
 from app.config import settings
+from app.services.realtime_config import REALTIME_MODEL, build_ws_session_update
 
 logger = logging.getLogger(__name__)
 
-REALTIME_MODEL = "gpt-realtime-mini"
 REALTIME_URL = f"wss://api.openai.com/v1/realtime?model={REALTIME_MODEL}"
 
 
@@ -90,8 +90,11 @@ async def stream_realtime(
         else:
             conversation_items.append(msg)
 
-    if tts_instructions:
-        system_content += f"\n\n[Voice style: {tts_instructions}]"
+    session_payload = build_ws_session_update(
+        voice=voice,
+        instructions=system_content,
+        tts_instructions=tts_instructions,
+    )
 
     try:
         async with websockets.connect(REALTIME_URL, additional_headers=headers, close_timeout=5) as ws:
@@ -99,13 +102,7 @@ async def stream_realtime(
 
             await ws.send(json.dumps({
                 "type": "session.update",
-                "session": {
-                    "modalities": ["text", "audio"],
-                    "voice": voice,
-                    "instructions": system_content,
-                    "output_audio_format": "pcm16",
-                    "turn_detection": None,
-                }
+                "session": session_payload,
             }))
 
             for item in conversation_items:

--- a/app/services/realtime_session_service.py
+++ b/app/services/realtime_session_service.py
@@ -1,0 +1,182 @@
+"""Mint short-lived OpenAI Realtime session tokens for the browser.
+
+The browser connects directly to OpenAI's Realtime API over WebRTC to run a
+voice conversation — we never relay audio through our backend. To do that the
+browser needs a `client_secret` (ephemeral token) scoped to a specific session
+config. This module owns the mint flow:
+
+  1. Load the Conversation and verify the caller owns it.
+  2. Run the paywall check so free-tier users past their quota can't spin up
+     a realtime session.
+  3. Rate-limit mints at (user_id, conversation_id) granularity — prevents
+     refresh-spam from burning OpenAI quota when the FE reconnects in a loop.
+  4. Build the ephemeral session config via `build_session_config(..., mode=
+     "ephemeral")` so the minted token already carries the right system prompt,
+     voice, VAD, and transcription settings.
+  5. POST to OpenAI's `/v1/realtime/sessions` and return the client_secret +
+     metadata straight through.
+
+Tokens have a short TTL (typically ~60s); the FE re-mints before expiry. If
+this module's OpenAI call fails we surface a 502 — the FE should not treat
+that as a conversation-level error and should fall back to the legacy
+`/voice-turn` flow behind its feature flag.
+"""
+import logging
+import time
+from typing import Tuple
+from uuid import UUID
+
+import httpx
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models import Conversation, User
+from app.services.realtime_config import build_session_config
+from app.services.subscription_service import check_paywall
+
+logger = logging.getLogger(__name__)
+
+OPENAI_REALTIME_SESSIONS_URL = "https://api.openai.com/v1/realtime/sessions"
+OPENAI_REQUEST_TIMEOUT_SECONDS = 10
+
+# Rate limit: one mint per (user_id, conversation_id) per this window.
+# v1 uses a process-local dict — fine for single-worker QA and acceptable on
+# Railway where workers are typically ≤2. If we scale out, move to Redis so
+# the limit holds across workers; rate-limit bypass only costs OpenAI cents.
+RATE_LIMIT_WINDOW_SECONDS = 30
+_rate_limit_state: dict[Tuple[str, str], float] = {}
+
+
+def _reset_rate_limit_state_for_tests() -> None:
+    """Clear the process-local rate limit dict. Tests call this in setup so
+    one test's mints don't bleed into the next."""
+    _rate_limit_state.clear()
+
+
+def _check_rate_limit(user_id: str, conversation_id: str) -> None:
+    """Raise 429 if this (user, conversation) minted within the window."""
+    key = (user_id, conversation_id)
+    now = time.monotonic()
+    last = _rate_limit_state.get(key)
+    if last is not None and (now - last) < RATE_LIMIT_WINDOW_SECONDS:
+        retry_after = max(1, int(RATE_LIMIT_WINDOW_SECONDS - (now - last)))
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "error": "RATE_LIMITED",
+                "retry_after_seconds": retry_after,
+            },
+        )
+    _rate_limit_state[key] = now
+
+
+async def mint_ephemeral_session(
+    conversation_id: UUID,
+    current_user: User,
+    db: Session,
+    phase: str,
+) -> dict:
+    """Validate, build config, and mint an OpenAI Realtime client_secret.
+
+    Returns a plain dict matching `RealtimeSessionResponse`'s shape. Raises
+    `HTTPException` for every failure mode; the router just returns the dict.
+
+    Ordering note: ownership check fires before paywall so a user probing
+    someone else's conversation_id always sees 403 FORBIDDEN, never
+    PAYWALL — that would leak which ids map to free-tier-exhausted accounts.
+    """
+    # Lazy imports to avoid circulars at module import time.
+    from app.api.v1.situations import get_grammar_level, get_vocab_level
+
+    conv = (
+        db.query(Conversation)
+        .filter(Conversation.id == conversation_id)
+        .first()
+    )
+    if conv is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Conversation not found",
+        )
+
+    if conv.user_id != current_user.id:
+        # Don't leak existence — 403 with a generic error, not 404.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error": "FORBIDDEN"},
+        )
+
+    # Paywall check — admins bypass, matching the /voice-turn pattern.
+    if not current_user.is_admin:
+        allowed, error = check_paywall(db, str(current_user.id), conv.situation_id)
+        if not allowed:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": error},
+            )
+
+    _check_rate_limit(str(current_user.id), str(conv.id))
+
+    vocab_level = get_vocab_level(db, current_user.id)
+    grammar_level = get_grammar_level(db, current_user.id)
+    session_config = build_session_config(
+        conv,
+        phase=phase,
+        db=db,
+        alt_language=current_user.alt_language,
+        vocab_level=vocab_level,
+        grammar_level=grammar_level,
+        mode="ephemeral",
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=OPENAI_REQUEST_TIMEOUT_SECONDS) as client:
+            r = await client.post(
+                OPENAI_REALTIME_SESSIONS_URL,
+                headers={
+                    "Authorization": f"Bearer {settings.openai_api_key}",
+                    "Content-Type": "application/json",
+                    "OpenAI-Beta": "realtime=v1",
+                },
+                json=session_config,
+            )
+        r.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            "[Realtime Session] OpenAI returned %s: %s",
+            e.response.status_code,
+            e.response.text[:200],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Realtime session provider returned an error",
+        )
+    except httpx.RequestError as e:
+        logger.error("[Realtime Session] OpenAI unreachable: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Realtime session provider unreachable",
+        )
+
+    body = r.json()
+    client_secret_obj = body.get("client_secret") or {}
+    if not client_secret_obj.get("value") or not client_secret_obj.get("expires_at"):
+        # OpenAI 200'd but didn't return what we need — treat as upstream failure
+        # rather than returning a malformed response that the FE can't act on.
+        logger.error(
+            "[Realtime Session] OpenAI response missing client_secret fields: %s",
+            str(body)[:200],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Realtime session provider returned an incomplete response",
+        )
+
+    return {
+        "client_secret": client_secret_obj["value"],
+        "expires_at": client_secret_obj["expires_at"],
+        # Fall back to the config we sent if OpenAI doesn't echo these.
+        "model": body.get("model") or session_config["model"],
+        "voice": body.get("voice") or session_config["voice"],
+    }

--- a/app/services/voice_turn_service.py
+++ b/app/services/voice_turn_service.py
@@ -1,5 +1,9 @@
-from typing import List, Optional
-from app.models import Word, Situation
+from typing import List, Optional, Tuple
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models import Conversation, Word, Situation
 from app.data.grammar_situations import get_grammar_config
 from app.data.situation_roles import (
     get_roles_for_situation,
@@ -7,6 +11,19 @@ from app.data.situation_roles import (
     GRAMMAR_SCENE_MAP,
 )
 from app.services.alt_language_service import get_target_language_name
+
+
+# Hard limit on persisted turns per voice conversation. Mirrors the FE's
+# ImmersiveVoiceScene EXCHANGE_HARD_LIMIT — keeping them in lockstep means
+# the client and server agree on when the session must close. Realtime
+# sessions need this as an explicit backstop because the backend doesn't
+# orchestrate each round-trip; legacy /voice-turn picks it up too so
+# behavior converges across flows.
+EXCHANGE_HARD_LIMIT = 30
+
+# FE-facing value for the "N turns left" countdown. FE shows warnings as
+# turns_remaining decreases from this baseline; stays at 0 once passed.
+EXCHANGE_WARNING_THRESHOLD = 25
 
 
 def get_language_mode(encounter_number: int, vocab_level: int, grammar_level: float = 0) -> str:
@@ -138,3 +155,138 @@ def build_conversation_prompt(
         f"User said: {user_transcript}\n\n"
         f"Ask a natural question requiring a missing {lang} word. Do NOT mention the {lang} word."
     )
+
+
+# ── Post-turn ingestion primitives ────────────────────────────────────────────
+# Three focused helpers consumed by the legacy /voice-turn flow AND the new
+# /realtime-turn endpoint. Splitting them here (instead of inlining as before)
+# means word detection, persistence, and completion logic can't drift between
+# the two flows — a parity bug that the realtime migration would otherwise
+# quietly introduce.
+
+
+def detect_words(
+    db: Session,
+    conversation: Conversation,
+    transcript: str,
+    alt_language: Optional[str] = None,
+) -> List[str]:
+    """Deterministic word/phrase detection against this conversation's targets.
+
+    Preserves the grammar-aware matching behavior the legacy /voice-turn used:
+    for grammar situations with a populated `drill_config.answers`, any
+    conjugated form matches its infinitive's `grammar_<verb>` id (mirrors the
+    FE logic at ImmersiveVoiceScene.tsx:452-462). Non-grammar situations fall
+    back to word-boundary matching on the target words.
+
+    Returns only the detected target ids — deduped, empty on empty transcript.
+    """
+    if not transcript:
+        return []
+
+    # Local imports to avoid circulars at module load time.
+    from app.services.alt_language_service import apply_alt_language
+    from app.services.word_detection import (
+        detect_grammar_words_in_text,
+        detect_words_in_text,
+        get_words_by_ids,
+    )
+
+    words = get_words_by_ids(db, conversation.target_word_ids or [])
+    words = apply_alt_language(words, alt_language, db)
+
+    grammar_config = get_grammar_config(conversation.situation_id)
+    answers = (grammar_config or {}).get("drill_config", {}).get("answers")
+    if grammar_config and answers:
+        return detect_grammar_words_in_text(transcript, words, answers)
+    return detect_words_in_text(transcript, words)
+
+
+def persist_turn(
+    db: Session,
+    conversation: Conversation,
+    user_id: UUID,
+    user_transcript: str,
+    assistant_text: str = "",
+    alt_language: Optional[str] = None,
+) -> Tuple[Conversation, List[str]]:
+    """Record one user turn: detect, extend used_spoken_word_ids, increment turn_count.
+
+    Shared between legacy `/voice-turn` (called after STT) and the new
+    `/realtime-turn` endpoint (called by the FE after each completed WebRTC
+    turn). The caller is responsible for committing the session and for
+    running `check_completion` afterward — those two concerns are kept
+    separate so tests can introspect intermediate state and so the legacy
+    flow can defer the completion check to its second-step endpoint.
+
+    Side effects:
+    - Appends detected ids to `used_spoken_word_ids` (deduped).
+    - Increments `turn_count` by 1.
+    - Upserts `user_words` spoken counters for each detected id.
+    - Records the `first_word` milestone the first time a target word lands
+      in a lesson-type conversation (idempotent via unique constraint).
+
+    `assistant_text` is accepted for parity with the `/realtime-turn`
+    contract but NOT persisted today — the `conversations` table doesn't
+    store message text (FE owns the transcript log). Kept in the signature
+    so we can start persisting without changing callers when we need to.
+
+    Returns `(conversation, detected_word_ids)` so callers can build their
+    response shape without re-computing detection.
+    """
+    # Local imports to keep this module import-safe.
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    from app.models import UserMilestoneEvent
+    from app.services.conversation_service import update_user_word_stats
+
+    detected_word_ids = detect_words(db, conversation, user_transcript, alt_language)
+
+    was_empty = len(conversation.used_spoken_word_ids or []) == 0
+    current_used = set(conversation.used_spoken_word_ids or [])
+    current_used.update(detected_word_ids)
+    conversation.used_spoken_word_ids = list(current_used)
+    conversation.turn_count = (conversation.turn_count or 0) + 1
+
+    if detected_word_ids:
+        update_user_word_stats(db, str(user_id), detected_word_ids, "voice")
+
+    if was_empty and detected_word_ids and conversation.conversation_type == "lesson":
+        target_set = set(conversation.target_word_ids or [])
+        if any(w in target_set for w in detected_word_ids):
+            db.execute(
+                pg_insert(UserMilestoneEvent)
+                .values(
+                    user_id=user_id,
+                    milestone_key="first_word",
+                    situation_id=conversation.situation_id,
+                    conversation_id=conversation.id,
+                )
+                .on_conflict_do_nothing(constraint="uq_user_milestone_situation")
+            )
+
+    return conversation, detected_word_ids
+
+
+def check_completion(conversation: Conversation) -> Tuple[bool, int]:
+    """Return (complete, turns_remaining) for a voice conversation.
+
+    `complete` fires when EITHER:
+      - every target word has been spoken at least once, OR
+      - `turn_count >= EXCHANGE_HARD_LIMIT` — safety net for open-ended
+        realtime sessions (and, by convergence, any legacy /voice-turn that
+        runs past the threshold).
+
+    `turns_remaining` counts down from `EXCHANGE_WARNING_THRESHOLD` so the FE
+    can surface a "N turns left" warning before the hard limit. Stays at 0
+    once the threshold is passed; consumers that don't need it can ignore it.
+    """
+    target = set(conversation.target_word_ids or [])
+    used = set(conversation.used_spoken_word_ids or [])
+    words_complete = bool(target) and target.issubset(used)
+
+    turn_count = conversation.turn_count or 0
+    turn_limit_hit = turn_count >= EXCHANGE_HARD_LIMIT
+
+    complete = words_complete or turn_limit_hit
+    turns_remaining = max(0, EXCHANGE_WARNING_THRESHOLD - turn_count)
+    return complete, turns_remaining

--- a/migrations/versions/020_add_conversation_turn_count.py
+++ b/migrations/versions/020_add_conversation_turn_count.py
@@ -1,0 +1,37 @@
+"""Add turn_count to conversations
+
+Revision ID: 020_conversation_turn_count
+Revises: 019_freeflow_timestamps
+Create Date: 2026-04-22
+
+Backs the hard-limit enforcement introduced alongside the realtime voice-chat
+flow. The realtime path can't be implicitly bounded by per-turn REST calls
+(the browser talks to OpenAI directly), so `persist_turn` increments this
+counter on every ingested turn and `check_completion` fires
+conversation_complete once it hits 30 — matching the FE's
+EXCHANGE_HARD_LIMIT.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "020_conversation_turn_count"
+down_revision = "019_freeflow_timestamps"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "turn_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("conversations", "turn_count")

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1,0 +1,466 @@
+"""HTTP-level tests for POST /v1/realtime/sessions.
+
+Covers:
+- Happy path: 201 + well-shaped body, passes through client_secret metadata.
+- Ownership: 403 FORBIDDEN when the conversation belongs to another user.
+- Not found: 404 for a random UUID.
+- Paywall: 403 {error: "PAYWALL"} when the free tier is exhausted.
+- Rate limit: 429 on a second mint within the window.
+- OpenAI upstream errors: 502 for both 5xx and transport failures.
+
+All tests mock `httpx.AsyncClient` used inside `realtime_session_service`, so
+no network calls. DB work (Conversation, Situation, Subscription rows) runs
+against the test Postgres via tests/conftest.py — SQLite is not compatible
+with the JSONB/UUID columns per CLAUDE.md.
+"""
+import uuid
+
+import pytest
+
+from app.models import Conversation, Situation, Subscription, UserSituation
+from app.services.realtime_session_service import (
+    _reset_rate_limit_state_for_tests,
+)
+from tests.conftest import register_user
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _get_auth_user_id(headers):
+    from jose import jwt
+    token = headers["Authorization"].split()[1]
+    payload = jwt.get_unverified_claims(token)
+    return uuid.UUID(payload["sub"])
+
+
+def _seed_banking_situation(db):
+    sit = Situation(
+        id="bank_open_rt",
+        title="Open Bank Account",
+        animation_type="banking",
+        encounter_number=1,
+        order_index=1,
+        is_free=True,
+    )
+    db.add(sit)
+    db.flush()
+    return sit
+
+
+def _make_voice_conversation(db, user_id, situation_id="bank_open_rt"):
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        situation_id=situation_id,
+        mode="voice",
+        target_word_ids=[],
+        used_typed_word_ids=[],
+        used_spoken_word_ids=[],
+        status="active",
+    )
+    db.add(conv)
+    db.flush()
+    return conv
+
+
+class _FakeResponse:
+    """httpx.Response-alike with just the bits realtime_session_service uses."""
+
+    def __init__(self, *, status_code=200, body=None):
+        self.status_code = status_code
+        self.text = ""
+        self._body = body or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import httpx
+            req = httpx.Request("POST", "https://example.test")
+            raise httpx.HTTPStatusError(
+                f"{self.status_code}", request=req, response=self  # type: ignore[arg-type]
+            )
+
+    def json(self):
+        return self._body
+
+
+def _fake_openai_response(
+    *,
+    status_code: int = 200,
+    client_secret_value: str = "ek_test_abc123",
+    expires_at: int = 1776900000,
+    model: str = "gpt-realtime-mini",
+    voice: str = "shimmer",
+    body_override: dict | None = None,
+):
+    """Build a fake httpx.Response-alike matching OpenAI's shape."""
+    if body_override is not None:
+        body = body_override
+    else:
+        body = {
+            "id": "sess_test",
+            "object": "realtime.session",
+            "model": model,
+            "voice": voice,
+            "client_secret": {"value": client_secret_value, "expires_at": expires_at},
+        }
+    return _FakeResponse(status_code=status_code, body=body)
+
+
+class _FakeAsyncClient:
+    """Context-managed stand-in for httpx.AsyncClient used in the service.
+
+    Captures the last call's args so tests can assert we posted the right
+    session config to OpenAI.
+    """
+
+    _response = None  # class-level; reset per test via monkeypatch
+    _raise_on_post = None
+    last_call = {}
+
+    def __init__(self, *args, **kwargs):
+        self.init_kwargs = kwargs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, *, headers=None, json=None, **_):
+        _FakeAsyncClient.last_call = {"url": url, "headers": headers, "json": json}
+        if _FakeAsyncClient._raise_on_post is not None:
+            raise _FakeAsyncClient._raise_on_post
+        return _FakeAsyncClient._response
+
+
+@pytest.fixture
+def fake_httpx(monkeypatch):
+    """Install _FakeAsyncClient in place of httpx.AsyncClient for the service.
+
+    Yields a controller with `.set_response(...)` and `.raise_on_post(exc)`
+    helpers so each test can dictate OpenAI's response.
+    """
+    _reset_rate_limit_state_for_tests()
+    _FakeAsyncClient._response = _fake_openai_response()
+    _FakeAsyncClient._raise_on_post = None
+    _FakeAsyncClient.last_call = {}
+
+    monkeypatch.setattr(
+        "app.services.realtime_session_service.httpx.AsyncClient",
+        _FakeAsyncClient,
+    )
+
+    class _Controller:
+        def set_response(self, resp):
+            _FakeAsyncClient._response = resp
+
+        def raise_on_post(self, exc):
+            _FakeAsyncClient._raise_on_post = exc
+
+        @property
+        def last_call(self):
+            return _FakeAsyncClient.last_call
+
+    yield _Controller()
+
+    _reset_rate_limit_state_for_tests()
+
+
+# ── Happy path ────────────────────────────────────────────────────────────────
+
+
+def test_create_session_happy_path(client, db, auth_user, fake_httpx):
+    """201 + all four fields present, and the session config posted to OpenAI
+    carries the expected model + voice for this situation."""
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_banking_situation(db)
+    conv = _make_voice_conversation(db, user_id)
+
+    resp = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(conv.id)},
+        headers=headers,
+    )
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["client_secret"] == "ek_test_abc123"
+    assert body["expires_at"] == 1776900000
+    assert body["model"] == "gpt-realtime-mini"
+    assert body["voice"] == "shimmer"
+
+    # Verify we posted the right session config to OpenAI.
+    posted = fake_httpx.last_call["json"]
+    assert posted["model"] == "gpt-realtime-mini"
+    assert posted["voice"] == "shimmer"  # banking situation
+    assert posted["turn_detection"] == {
+        "type": "server_vad",
+        "threshold": 0.5,
+        "silence_duration_ms": 500,
+    }
+    assert posted["input_audio_transcription"] == {"model": "whisper-1"}
+    assert fake_httpx.last_call["url"] == (
+        "https://api.openai.com/v1/realtime/sessions"
+    )
+    assert fake_httpx.last_call["headers"]["OpenAI-Beta"] == "realtime=v1"
+
+
+# ── Validation / missing conversation ─────────────────────────────────────────
+
+
+def test_create_session_conversation_not_found(client, auth_user, fake_httpx):
+    _, headers = auth_user
+    resp = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(uuid.uuid4())},
+        headers=headers,
+    )
+    assert resp.status_code == 404, resp.text
+
+
+def test_create_session_malformed_uuid_422(client, auth_user, fake_httpx):
+    """Pydantic should reject a non-UUID body before the service runs."""
+    _, headers = auth_user
+    resp = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": "not-a-uuid"},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+# ── Ownership ────────────────────────────────────────────────────────────────
+
+
+def test_create_session_rejects_foreign_conversation(client, db, auth_user, fake_httpx):
+    """User A asking for a client_secret on User B's conversation → 403 FORBIDDEN,
+    not 404 (404 would leak which ids exist)."""
+    _, headers_a = auth_user
+
+    # Create user B + their own conversation
+    _, headers_b = register_user(client, email="other@example.com")
+    user_b_id = _get_auth_user_id(headers_b)
+    _seed_banking_situation(db)
+    conv_b = _make_voice_conversation(db, user_b_id)
+
+    resp = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(conv_b.id)},
+        headers=headers_a,
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["detail"] == {"error": "FORBIDDEN"}
+
+
+# ── Paywall ───────────────────────────────────────────────────────────────────
+
+
+def test_create_session_paywall_blocks_exhausted_free_user(
+    client, db, auth_user, fake_httpx
+):
+    """Free user who has completed the free-tier limit on non-grammar
+    encounters → 403 {error: 'PAYWALL'}."""
+    from app.services.subscription_service import FREE_ENCOUNTERS_LIMIT
+
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_banking_situation(db)
+    conv = _make_voice_conversation(db, user_id)
+
+    # Give the user an inactive subscription (default) and N completed
+    # non-grammar encounters to trip the gate.
+    db.add(Subscription(user_id=user_id, active=False))
+    for i in range(FREE_ENCOUNTERS_LIMIT):
+        sit = Situation(
+            id=f"bank_paywall_{i}",
+            title=f"Paywall seed {i}",
+            animation_type="banking",
+            encounter_number=i + 2,
+            order_index=100 + i,
+            is_free=True,
+        )
+        db.add(sit)
+        db.flush()
+        db.add(UserSituation(
+            user_id=user_id,
+            situation_id=sit.id,
+            completed_at=__import__("datetime").datetime.now(
+                __import__("datetime").timezone.utc
+            ),
+        ))
+    db.flush()
+
+    resp = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(conv.id)},
+        headers=headers,
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["detail"] == {"error": "PAYWALL"}
+
+
+def test_create_session_admin_bypasses_paywall(client, db, auth_user, fake_httpx):
+    """is_admin=True should bypass the paywall — matches /voice-turn's behavior."""
+    from app.models import User
+    from app.services.subscription_service import FREE_ENCOUNTERS_LIMIT
+
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    db.query(User).filter(User.id == user_id).update({"is_admin": True})
+    _seed_banking_situation(db)
+    conv = _make_voice_conversation(db, user_id)
+
+    # Seed enough completions that a non-admin would be paywalled.
+    for i in range(FREE_ENCOUNTERS_LIMIT):
+        sit = Situation(
+            id=f"bank_admin_{i}",
+            title=f"Admin seed {i}",
+            animation_type="banking",
+            encounter_number=i + 2,
+            order_index=200 + i,
+            is_free=True,
+        )
+        db.add(sit)
+        db.flush()
+        db.add(UserSituation(
+            user_id=user_id,
+            situation_id=sit.id,
+            completed_at=__import__("datetime").datetime.now(
+                __import__("datetime").timezone.utc
+            ),
+        ))
+    db.flush()
+
+    resp = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(conv.id)},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+
+# ── Rate limit ───────────────────────────────────────────────────────────────
+
+
+def test_create_session_rate_limited_on_second_call(client, db, auth_user, fake_httpx):
+    """Two mints for the same (user, conversation) within the window →
+    first 201, second 429 with retry_after_seconds."""
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_banking_situation(db)
+    conv = _make_voice_conversation(db, user_id)
+
+    r1 = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(conv.id)},
+        headers=headers,
+    )
+    assert r1.status_code == 201, r1.text
+
+    r2 = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(conv.id)},
+        headers=headers,
+    )
+    assert r2.status_code == 429, r2.text
+    detail = r2.json()["detail"]
+    assert detail["error"] == "RATE_LIMITED"
+    assert isinstance(detail["retry_after_seconds"], int)
+    assert detail["retry_after_seconds"] >= 1
+
+
+def test_create_session_rate_limit_is_per_conversation(client, db, auth_user, fake_httpx):
+    """Rate limit keys on (user, conversation) — a second conversation
+    for the same user should still mint."""
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_banking_situation(db)
+    conv1 = _make_voice_conversation(db, user_id)
+    conv2 = _make_voice_conversation(db, user_id)
+
+    r1 = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(conv1.id)},
+        headers=headers,
+    )
+    r2 = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(conv2.id)},
+        headers=headers,
+    )
+    assert r1.status_code == 201
+    assert r2.status_code == 201
+
+
+# ── OpenAI upstream failures ─────────────────────────────────────────────────
+
+
+def test_create_session_openai_5xx_returns_502(client, db, auth_user, fake_httpx):
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_banking_situation(db)
+    conv = _make_voice_conversation(db, user_id)
+
+    fake_httpx.set_response(_fake_openai_response(status_code=503))
+
+    resp = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(conv.id)},
+        headers=headers,
+    )
+    assert resp.status_code == 502, resp.text
+
+
+def test_create_session_openai_unreachable_returns_502(client, db, auth_user, fake_httpx):
+    import httpx
+
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_banking_situation(db)
+    conv = _make_voice_conversation(db, user_id)
+
+    fake_httpx.raise_on_post(httpx.ConnectError("boom"))
+
+    resp = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(conv.id)},
+        headers=headers,
+    )
+    assert resp.status_code == 502, resp.text
+
+
+def test_create_session_openai_returns_incomplete_body_is_502(
+    client, db, auth_user, fake_httpx
+):
+    """Guard: if OpenAI 200s but without client_secret.value, we must not
+    return a malformed shape to the FE."""
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_banking_situation(db)
+    conv = _make_voice_conversation(db, user_id)
+
+    fake_httpx.set_response(
+        _fake_openai_response(body_override={"id": "sess_x", "model": "gpt-realtime-mini"})
+    )
+
+    resp = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(conv.id)},
+        headers=headers,
+    )
+    assert resp.status_code == 502, resp.text
+
+
+# ── Auth ─────────────────────────────────────────────────────────────────────
+
+
+def test_create_session_requires_auth(client, fake_httpx):
+    resp = client.post(
+        "/v1/realtime/sessions",
+        json={"conversation_id": str(uuid.uuid4())},
+    )
+    # Matches other authed endpoints — 401/403 depending on get_current_user
+    # implementation. Accept either so the test isn't brittle.
+    assert resp.status_code in (401, 403)

--- a/tests/test_realtime_turn.py
+++ b/tests/test_realtime_turn.py
@@ -1,0 +1,340 @@
+"""HTTP-level tests for POST /v1/conversations/{id}/realtime-turn.
+
+The endpoint is the FE's post-turn ingestion hook for the realtime voice
+flow. These tests go through the FastAPI test client and exercise the full
+stack: ownership check, word detection (regular + grammar-aware), turn_count
+enforcement, and response shape.
+
+No network — the endpoint has no outbound calls (detection + persistence
+are deterministic against the DB).
+"""
+import uuid
+
+import pytest
+
+from app.models import Conversation, Situation, User, Word
+from app.services.voice_turn_service import (
+    EXCHANGE_HARD_LIMIT,
+    EXCHANGE_WARNING_THRESHOLD,
+)
+from tests.conftest import register_user
+
+
+def _get_auth_user_id(headers):
+    from jose import jwt
+    token = headers["Authorization"].split()[1]
+    payload = jwt.get_unverified_claims(token)
+    return uuid.UUID(payload["sub"])
+
+
+def _seed_banking(db):
+    sit = Situation(
+        id="bank_rt_turn",
+        title="Test Banking",
+        animation_type="banking",
+        encounter_number=1,
+        order_index=1,
+        is_free=True,
+    )
+    db.add(sit)
+    words = [
+        Word(id="wr_cuenta", spanish="cuenta", english="account", word_category="encounter"),
+        Word(id="wr_depositar", spanish="depositar", english="to deposit", word_category="encounter"),
+        Word(id="wr_retirar", spanish="retirar", english="to withdraw", word_category="encounter"),
+    ]
+    for w in words:
+        db.add(w)
+    db.flush()
+    return [w.id for w in words]
+
+
+def _make_conversation(
+    db, user_id, target_word_ids, *,
+    used_spoken_word_ids=None, turn_count=0,
+):
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        situation_id="bank_rt_turn",
+        mode="voice",
+        target_word_ids=target_word_ids,
+        used_typed_word_ids=[],
+        used_spoken_word_ids=used_spoken_word_ids or [],
+        status="active",
+        turn_count=turn_count,
+    )
+    db.add(conv)
+    db.flush()
+    return conv
+
+
+# ── Happy path ──────────────────────────────────────────────────────────────
+
+
+def test_realtime_turn_happy_path(client, db, auth_user):
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    target_ids = _seed_banking(db)
+    conv = _make_conversation(db, user_id, target_ids)
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/realtime-turn",
+        json={
+            "user_transcript": "Quiero abrir una cuenta",
+            "assistant_text": "Perfecto, vamos a abrirla.",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["detected_word_ids"] == ["wr_cuenta"]
+    assert set(body["missing_word_ids"]) == {"wr_depositar", "wr_retirar"}
+    assert body["conversation_complete"] is False
+    assert body["turns_remaining"] == EXCHANGE_WARNING_THRESHOLD - 1
+
+
+def test_realtime_turn_empty_transcript_still_increments_turn(client, db, auth_user):
+    """Empty transcript shouldn't 4xx — sometimes OpenAI returns no transcript
+    (background noise, silence). We still count the turn to keep the hard
+    limit honest."""
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    target_ids = _seed_banking(db)
+    conv = _make_conversation(db, user_id, target_ids)
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/realtime-turn",
+        json={"user_transcript": "", "assistant_text": ""},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["detected_word_ids"] == []
+    assert set(body["missing_word_ids"]) == set(target_ids)
+    assert body["conversation_complete"] is False
+
+    db.refresh(conv)
+    assert conv.turn_count == 1
+
+
+def test_realtime_turn_all_words_detected_triggers_completion(client, db, auth_user):
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    target_ids = _seed_banking(db)
+    conv = _make_conversation(
+        db, user_id, target_ids,
+        used_spoken_word_ids=[target_ids[0], target_ids[1]],
+    )
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/realtime-turn",
+        json={
+            "user_transcript": "Ahora quiero retirar dinero",
+            "assistant_text": "Por supuesto.",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "wr_retirar" in body["detected_word_ids"]
+    assert body["missing_word_ids"] == []
+    assert body["conversation_complete"] is True
+
+    db.refresh(conv)
+    assert conv.status == "complete"
+    assert conv.completed_at is not None
+
+
+def test_realtime_turn_hard_limit_forces_complete_regardless_of_words(
+    client, db, auth_user
+):
+    """At turn 30 the conversation must complete even if the user hasn't
+    spoken all target words. Matches EXCHANGE_HARD_LIMIT on the FE; the
+    realtime flow relies on this because the backend can't pull the plug
+    on an OpenAI session otherwise."""
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    target_ids = _seed_banking(db)
+    # Conversation sits at turn_count=29; next ingestion brings it to 30.
+    conv = _make_conversation(
+        db, user_id, target_ids,
+        turn_count=EXCHANGE_HARD_LIMIT - 1,
+    )
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/realtime-turn",
+        json={
+            "user_transcript": "just some filler with no target words",
+            "assistant_text": "ok",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["detected_word_ids"] == []
+    # Targets still missing but completion fires via the hard limit.
+    assert body["conversation_complete"] is True
+    assert body["turns_remaining"] == 0
+
+    db.refresh(conv)
+    assert conv.turn_count == EXCHANGE_HARD_LIMIT
+    assert conv.status == "complete"
+
+
+def test_realtime_turn_turn_29_not_yet_complete(client, db, auth_user):
+    """Turn 29 (one-before-hard-limit) should NOT flip complete on its own."""
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    target_ids = _seed_banking(db)
+    conv = _make_conversation(
+        db, user_id, target_ids,
+        turn_count=EXCHANGE_HARD_LIMIT - 2,  # 28 → becomes 29 after this call
+    )
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/realtime-turn",
+        json={
+            "user_transcript": "nothing",
+            "assistant_text": "",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["conversation_complete"] is False
+
+    db.refresh(conv)
+    assert conv.turn_count == EXCHANGE_HARD_LIMIT - 1
+    assert conv.status == "active"
+
+
+# ── Ownership / auth ─────────────────────────────────────────────────────────
+
+
+def test_realtime_turn_rejects_foreign_conversation(client, db, auth_user):
+    """Another user's conversation must 404 — same behavior as /voice-turn.
+    Not a 403 here: /voice-turn uses a combined user+id filter that returns
+    404 for non-ownership, and we mirror that rather than adding a new
+    leak-shape at this endpoint."""
+    _, headers_a = auth_user
+
+    _, headers_b = register_user(client, email="rt_other@example.com")
+    user_b_id = _get_auth_user_id(headers_b)
+    target_ids = _seed_banking(db)
+    conv_b = _make_conversation(db, user_b_id, target_ids)
+
+    resp = client.post(
+        f"/v1/conversations/{conv_b.id}/realtime-turn",
+        json={"user_transcript": "x", "assistant_text": "y"},
+        headers=headers_a,
+    )
+    assert resp.status_code == 404
+
+
+def test_realtime_turn_conversation_not_found(client, auth_user, db):
+    _, headers = auth_user
+    resp = client.post(
+        f"/v1/conversations/{uuid.uuid4()}/realtime-turn",
+        json={"user_transcript": "x", "assistant_text": "y"},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_realtime_turn_rejects_text_mode_conversation(client, db, auth_user):
+    """Conversations in 'text' mode shouldn't accept realtime-turn — the
+    endpoint only makes sense for voice."""
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_banking(db)
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        situation_id="bank_rt_turn",
+        mode="text",
+        target_word_ids=[],
+        used_typed_word_ids=[],
+        used_spoken_word_ids=[],
+        status="active",
+    )
+    db.add(conv)
+    db.flush()
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/realtime-turn",
+        json={"user_transcript": "x", "assistant_text": "y"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_realtime_turn_requires_auth(client, db):
+    resp = client.post(
+        f"/v1/conversations/{uuid.uuid4()}/realtime-turn",
+        json={"user_transcript": "x", "assistant_text": "y"},
+    )
+    assert resp.status_code in (401, 403)
+
+
+# ── Grammar-aware detection ─────────────────────────────────────────────────
+
+
+def test_realtime_turn_detects_grammar_verb_via_conjugated_form(client, db, auth_user):
+    """Grammar situations match any conjugated form from drill_config.answers
+    back to the infinitive's grammar_<verb> id. Mirrors FE behavior."""
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+
+    # grammar_regular_present_1 is defined in app/data/grammar_situations.py
+    # with drill_config.answers mapping verbs to all their conjugations.
+    from app.data.grammar_situations import get_grammar_config
+    config = get_grammar_config("grammar_regular_present_1")
+    if not config or not config.get("drill_config", {}).get("answers"):
+        pytest.skip("grammar_regular_present_1 drill config unavailable")
+    answers = config["drill_config"]["answers"]
+    # Pick the first verb/form deterministically.
+    verb = next(iter(answers.keys()))
+    conjugated = next(v for v in answers[verb].values() if v)
+
+    # Seed minimal grammar situation + base word
+    sit = Situation(
+        id="grammar_regular_present_1",
+        title="Regular Present 1",
+        animation_type="grammar",
+        encounter_number=300,
+        order_index=1300,
+        is_free=True,
+        situation_type="grammar",
+    )
+    db.add(sit)
+    word = Word(
+        id=f"grammar_{verb}",
+        spanish=verb,
+        english="to x",
+        word_category="grammar",
+    )
+    db.add(word)
+    db.flush()
+
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        situation_id="grammar_regular_present_1",
+        mode="voice",
+        target_word_ids=[f"grammar_{verb}"],
+        used_typed_word_ids=[],
+        used_spoken_word_ids=[],
+        status="active",
+    )
+    db.add(conv)
+    db.flush()
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/realtime-turn",
+        json={
+            "user_transcript": f"Yo {conjugated} todos los días.",
+            "assistant_text": "claro",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["detected_word_ids"] == [f"grammar_{verb}"]

--- a/tests/test_services/test_realtime_config.py
+++ b/tests/test_services/test_realtime_config.py
@@ -1,0 +1,267 @@
+"""Tests for `app/services/realtime_config.py`.
+
+Phase 1 of the realtime voice-chat migration: a single source of truth for
+the OpenAI Realtime session config so the new ephemeral/WebRTC endpoint and
+the legacy server-WS flow agree on system prompt + voice + model.
+
+These tests use the real `Conversation`/`Situation` models against the test
+Postgres (per `tests/conftest.py`) and snapshot the resulting config for
+representative situations and phases. No network calls — `build_session_config`
+is pure given a DB session.
+"""
+import uuid
+
+import pytest
+
+from app.auth import get_password_hash
+from app.models import Conversation, Situation, User
+from app.services.realtime_config import (
+    REALTIME_MODEL,
+    build_session_config,
+    build_ws_session_update,
+    resolve_voice,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _make_user(db) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"rt_{uuid.uuid4().hex[:8]}@test.com",
+        password_hash=get_password_hash("testpass123"),
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _make_situation(db, sid: str, animation_type: str, encounter_number: int = 1) -> Situation:
+    situation = Situation(
+        id=sid,
+        title=f"Test {sid}",
+        animation_type=animation_type,
+        encounter_number=encounter_number,
+        order_index=1,
+        is_free=True,
+    )
+    db.add(situation)
+    db.flush()
+    return situation
+
+
+def _make_conversation(db, user: User, situation: Situation) -> Conversation:
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        situation_id=situation.id,
+        mode="voice",
+        target_word_ids=[],
+        used_typed_word_ids=[],
+        used_spoken_word_ids=[],
+    )
+    db.add(conv)
+    db.flush()
+    return conv
+
+
+# ── resolve_voice ─────────────────────────────────────────────────────────────
+
+
+def test_resolve_voice_known_animation_type():
+    """Banking situations get shimmer; restaurant gets ash. Catalog lives in
+    SITUATION_VOICE_CONFIG — this test pins the contract."""
+    voice, instructions = resolve_voice("banking")
+    assert voice == "shimmer"
+    assert "Mexican Spanish" in instructions
+
+    voice, instructions = resolve_voice("restaurant")
+    assert voice == "ash"
+
+
+def test_resolve_voice_swaps_accent_for_alt_language():
+    """Catalan/Swedish modes replace the Mexican accent directive."""
+    _, es_instr = resolve_voice("banking")
+    _, ca_instr = resolve_voice("banking", alt_language="catalan")
+    _, sv_instr = resolve_voice("banking", alt_language="swedish")
+
+    assert "Mexican Spanish" in es_instr
+    assert "Catalan accent" in ca_instr
+    assert "Swedish accent" in sv_instr
+
+
+def test_resolve_voice_unknown_animation_type_falls_back():
+    """Unknown types default to alloy, no instructions — matches
+    get_tts_instructions behavior."""
+    voice, instructions = resolve_voice("nonexistent_animation_type_xyz")
+    assert voice == "alloy"
+    assert instructions is None
+
+
+# ── build_session_config: ephemeral mode ──────────────────────────────────────
+
+
+def test_ephemeral_config_carries_model_vad_and_whisper(db):
+    """Ephemeral config (browser → OpenAI WebRTC) must include the model name,
+    server VAD turn detection, and whisper transcription. Without these the
+    browser session can't endpoint user speech or hand transcripts back to us."""
+    user = _make_user(db)
+    situation = _make_situation(db, "bank_open_test", "banking")
+    conv = _make_conversation(db, user, situation)
+
+    cfg = build_session_config(conv, phase="2", db=db)
+
+    assert cfg["model"] == REALTIME_MODEL
+    assert cfg["modalities"] == ["text", "audio"]
+    assert cfg["voice"] == "shimmer"
+    assert cfg["turn_detection"] == {
+        "type": "server_vad",
+        "threshold": 0.5,
+        "silence_duration_ms": 500,
+    }
+    assert cfg["input_audio_transcription"] == {"model": "whisper-1"}
+    assert isinstance(cfg["instructions"], str) and cfg["instructions"]
+    # Ephemeral never sets output_audio_format — that's only meaningful when
+    # the server is decoding raw PCM from a WS stream.
+    assert "output_audio_format" not in cfg
+
+
+def test_ephemeral_config_for_grammar_situation_uses_grammar_prompt(db):
+    """Grammar situations have their own template — pin that the right one
+    flows into the ephemeral session so the model behaves as a drill agent."""
+    user = _make_user(db)
+    # `grammar_pronouns` is defined in app/data/grammar_situations.py
+    situation = _make_situation(db, "grammar_pronouns", "grammar")
+    conv = _make_conversation(db, user, situation)
+
+    cfg = build_session_config(conv, phase="2", db=db)
+
+    assert cfg["voice"] == "ash"  # grammar voice config
+    # Grammar prompt template is loaded from prompts.json — its content is
+    # implementation detail, but the prompt must exist and be non-empty.
+    assert cfg["instructions"]
+
+
+def test_ephemeral_config_alt_language_swaps_accent(db):
+    """Catalan mode rewrites the voice accent directive but keeps the same
+    voice slot. The system prompt also flips to Catalan."""
+    user = _make_user(db)
+    situation = _make_situation(db, "bank_open_alt", "banking")
+    conv = _make_conversation(db, user, situation)
+
+    es_cfg = build_session_config(conv, phase="2", db=db, alt_language=None)
+    ca_cfg = build_session_config(conv, phase="2", db=db, alt_language="catalan")
+
+    assert es_cfg["voice"] == ca_cfg["voice"] == "shimmer"
+    # System prompt should differ — alt-language flips the language token in
+    # the conversation_agent template.
+    assert es_cfg["instructions"] != ca_cfg["instructions"]
+
+
+def test_ephemeral_config_phase_does_not_affect_dict_today(db):
+    """Phase is carried through for observability today (no behavioral effect).
+    Pin that so a future change to make phase load-bearing has to update this
+    test deliberately."""
+    user = _make_user(db)
+    situation = _make_situation(db, "bank_open_phase", "banking")
+    conv = _make_conversation(db, user, situation)
+
+    cfg_p2 = build_session_config(conv, phase="2", db=db)
+    cfg_p3 = build_session_config(conv, phase="3", db=db)
+
+    assert cfg_p2 == cfg_p3
+
+
+def test_build_session_config_raises_for_missing_situation(db):
+    """If the situation row is gone (data integrity bug), fail loudly rather
+    than mint a session with a broken prompt."""
+    user = _make_user(db)
+    # Build a Conversation pointing at a nonexistent situation_id, bypassing
+    # the FK by not flushing it through the DB.
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        situation_id="does_not_exist_xyz",
+        mode="voice",
+        target_word_ids=[],
+        used_typed_word_ids=[],
+        used_spoken_word_ids=[],
+    )
+
+    with pytest.raises(ValueError, match="missing situation"):
+        build_session_config(conv, phase="2", db=db)
+
+
+# ── build_session_config: server_ws mode ──────────────────────────────────────
+
+
+def test_server_ws_config_disables_vad_and_omits_model(db):
+    """server_ws mode is for the legacy backend-orchestrated flow. The server
+    issues `response.create` itself, so VAD must be off; the model is encoded
+    in the WS URL, not the session payload."""
+    user = _make_user(db)
+    situation = _make_situation(db, "bank_open_ws", "banking")
+    conv = _make_conversation(db, user, situation)
+
+    cfg = build_session_config(conv, phase="2", db=db, mode="server_ws")
+
+    assert "model" not in cfg
+    assert cfg["turn_detection"] is None
+    assert cfg["output_audio_format"] == "pcm16"
+    assert "input_audio_transcription" not in cfg
+    assert cfg["voice"] == "shimmer"
+
+
+# ── build_ws_session_update ───────────────────────────────────────────────────
+
+
+def test_ws_session_update_matches_legacy_inline_payload():
+    """Pre-refactor, `realtime_service.stream_realtime` inlined this exact
+    payload. The helper must produce a byte-identical dict so the WS flow
+    behaves the same."""
+    voice = "shimmer"
+    system_prompt = "You are a helpful Spanish tutor."
+
+    payload = build_ws_session_update(voice=voice, instructions=system_prompt)
+
+    assert payload == {
+        "modalities": ["text", "audio"],
+        "voice": "shimmer",
+        "instructions": "You are a helpful Spanish tutor.",
+        "output_audio_format": "pcm16",
+        "turn_detection": None,
+    }
+
+
+def test_ws_session_update_appends_tts_style_directive():
+    """When tts_instructions is provided, the legacy code appended a
+    `[Voice style: ...]` block to the system prompt. Preserve that exactly —
+    the realtime model has been tuned around this directive shape."""
+    payload = build_ws_session_update(
+        voice="ash",
+        instructions="System prompt body.",
+        tts_instructions="Speak with a warm tone.",
+    )
+
+    assert payload["instructions"] == (
+        "System prompt body.\n\n[Voice style: Speak with a warm tone.]"
+    )
+
+
+def test_ws_session_update_no_tts_instructions_leaves_prompt_untouched():
+    """Falsy tts_instructions must not modify the prompt — guards against a
+    stray `\\n\\n[Voice style: None]` regression."""
+    payload = build_ws_session_update(
+        voice="ash",
+        instructions="Just the system prompt.",
+        tts_instructions=None,
+    )
+    assert payload["instructions"] == "Just the system prompt."
+
+    payload_empty = build_ws_session_update(
+        voice="ash",
+        instructions="Just the system prompt.",
+        tts_instructions="",
+    )
+    assert payload_empty["instructions"] == "Just the system prompt."

--- a/tests/test_services/test_voice_turn_persist.py
+++ b/tests/test_services/test_voice_turn_persist.py
@@ -1,0 +1,286 @@
+"""Unit tests for the Phase 2/3 voice-turn helpers.
+
+Covers `detect_words`, `persist_turn`, and `check_completion` in
+`app/services/voice_turn_service.py`. These run against the test Postgres
+(via tests/conftest.py) — they don't go through the HTTP layer, so they
+exercise edge cases that would be awkward to trigger from an endpoint test
+(e.g. constructing a conversation at turn_count=29).
+"""
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from app.auth import get_password_hash
+from app.models import Conversation, Situation, User, UserWord, Word
+from app.services.voice_turn_service import (
+    EXCHANGE_HARD_LIMIT,
+    EXCHANGE_WARNING_THRESHOLD,
+    check_completion,
+    detect_words,
+    persist_turn,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _make_user(db, *, email_suffix=None) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"vt_{email_suffix or uuid.uuid4().hex[:8]}@test.com",
+        password_hash=get_password_hash("testpass123"),
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _make_situation(db, *, sid="bank_open_vt", animation_type="banking") -> Situation:
+    sit = Situation(
+        id=sid,
+        title="Test Banking",
+        animation_type=animation_type,
+        encounter_number=1,
+        order_index=1,
+        is_free=True,
+    )
+    db.add(sit)
+    db.flush()
+    return sit
+
+
+def _seed_words(db):
+    words = [
+        Word(id="w_cuenta", spanish="cuenta", english="account", word_category="encounter"),
+        Word(id="w_depositar", spanish="depositar", english="to deposit", word_category="encounter"),
+        Word(id="w_retirar", spanish="retirar", english="to withdraw", word_category="encounter"),
+    ]
+    for w in words:
+        db.add(w)
+    db.flush()
+    return [w.id for w in words]
+
+
+def _make_conversation(
+    db,
+    user_id,
+    *,
+    situation_id="bank_open_vt",
+    target_word_ids=None,
+    used_spoken_word_ids=None,
+    turn_count=0,
+    conversation_type="lesson",
+):
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        situation_id=situation_id,
+        mode="voice",
+        conversation_type=conversation_type,
+        target_word_ids=target_word_ids or [],
+        used_typed_word_ids=[],
+        used_spoken_word_ids=used_spoken_word_ids or [],
+        status="active",
+        turn_count=turn_count,
+    )
+    db.add(conv)
+    db.flush()
+    return conv
+
+
+# ── detect_words ──────────────────────────────────────────────────────────────
+
+
+def test_detect_words_matches_target_words_in_transcript(db):
+    user = _make_user(db)
+    _make_situation(db)
+    target_ids = _seed_words(db)
+    conv = _make_conversation(db, user.id, target_word_ids=target_ids)
+
+    detected = detect_words(db, conv, "Quiero abrir una cuenta para depositar dinero.")
+    assert set(detected) == {"w_cuenta", "w_depositar"}
+
+
+def test_detect_words_empty_transcript_returns_empty(db):
+    user = _make_user(db)
+    _make_situation(db)
+    target_ids = _seed_words(db)
+    conv = _make_conversation(db, user.id, target_word_ids=target_ids)
+
+    assert detect_words(db, conv, "") == []
+    assert detect_words(db, conv, None) == []
+
+
+def test_detect_words_no_overlap_returns_empty(db):
+    user = _make_user(db)
+    _make_situation(db)
+    target_ids = _seed_words(db)
+    conv = _make_conversation(db, user.id, target_word_ids=target_ids)
+
+    assert detect_words(db, conv, "Hello how are you today friend") == []
+
+
+# ── persist_turn ──────────────────────────────────────────────────────────────
+
+
+def test_persist_turn_appends_detected_words_and_increments_turn_count(db):
+    user = _make_user(db)
+    _make_situation(db)
+    target_ids = _seed_words(db)
+    conv = _make_conversation(db, user.id, target_word_ids=target_ids)
+
+    _, detected = persist_turn(
+        db=db,
+        conversation=conv,
+        user_id=user.id,
+        user_transcript="quiero abrir una cuenta",
+        assistant_text="claro, con gusto",
+    )
+
+    db.flush()
+    assert detected == ["w_cuenta"]
+    assert conv.used_spoken_word_ids == ["w_cuenta"]
+    assert conv.turn_count == 1
+
+    # user_words counter got incremented for the detected word.
+    uw = db.query(UserWord).filter_by(user_id=user.id, word_id="w_cuenta").first()
+    assert uw is not None
+    assert uw.spoken_correct_count == 1
+
+
+def test_persist_turn_increments_turn_count_even_when_no_words_detected(db):
+    """The hard-limit safety net depends on turn_count counting empty turns,
+    otherwise a user who never says a target word can chat forever."""
+    user = _make_user(db)
+    _make_situation(db)
+    target_ids = _seed_words(db)
+    conv = _make_conversation(db, user.id, target_word_ids=target_ids, turn_count=5)
+
+    _, detected = persist_turn(
+        db=db,
+        conversation=conv,
+        user_id=user.id,
+        user_transcript="no relevant words here friend",
+        assistant_text="ok",
+    )
+
+    assert detected == []
+    assert conv.used_spoken_word_ids == []
+    assert conv.turn_count == 6
+
+
+def test_persist_turn_dedupes_already_detected_words(db):
+    """Saying a word twice shouldn't duplicate it in used_spoken_word_ids."""
+    user = _make_user(db)
+    _make_situation(db)
+    target_ids = _seed_words(db)
+    conv = _make_conversation(
+        db, user.id,
+        target_word_ids=target_ids,
+        used_spoken_word_ids=["w_cuenta"],
+    )
+
+    _, detected = persist_turn(
+        db=db,
+        conversation=conv,
+        user_id=user.id,
+        user_transcript="cuenta otra vez",
+        assistant_text="",
+    )
+
+    assert "w_cuenta" in detected
+    assert conv.used_spoken_word_ids.count("w_cuenta") == 1
+
+
+# ── check_completion ──────────────────────────────────────────────────────────
+
+
+def test_check_completion_all_target_words_used(db):
+    user = _make_user(db)
+    _make_situation(db)
+    target_ids = _seed_words(db)
+    conv = _make_conversation(
+        db, user.id,
+        target_word_ids=target_ids,
+        used_spoken_word_ids=target_ids,
+        turn_count=3,
+    )
+
+    complete, turns_remaining = check_completion(conv)
+    assert complete is True
+    assert turns_remaining == EXCHANGE_WARNING_THRESHOLD - 3
+
+
+def test_check_completion_missing_words_not_complete(db):
+    user = _make_user(db)
+    _make_situation(db)
+    target_ids = _seed_words(db)
+    conv = _make_conversation(
+        db, user.id,
+        target_word_ids=target_ids,
+        used_spoken_word_ids=[target_ids[0]],
+        turn_count=2,
+    )
+
+    complete, turns_remaining = check_completion(conv)
+    assert complete is False
+    assert turns_remaining == EXCHANGE_WARNING_THRESHOLD - 2
+
+
+def test_check_completion_hard_limit_fires_regardless_of_words(db):
+    """Turn 30 is the safety net — even with zero target words spoken, the
+    conversation must flip to complete so the FE closes the peer connection."""
+    assert EXCHANGE_HARD_LIMIT == 30
+
+    user = _make_user(db)
+    _make_situation(db)
+    target_ids = _seed_words(db)
+
+    # Turn 29 = not complete yet
+    conv_29 = _make_conversation(
+        db, user.id,
+        target_word_ids=target_ids,
+        used_spoken_word_ids=[],
+        turn_count=29,
+    )
+    complete, turns_remaining = check_completion(conv_29)
+    assert complete is False
+    assert turns_remaining == 0  # past threshold, pinned at 0
+
+    # Turn 30 = complete
+    conv_30 = _make_conversation(
+        db, _make_user(db, email_suffix="b").id,
+        target_word_ids=target_ids,
+        used_spoken_word_ids=[],
+        turn_count=30,
+    )
+    complete, _ = check_completion(conv_30)
+    assert complete is True
+
+    # Turn 31 = still complete (idempotent past the limit)
+    conv_31 = _make_conversation(
+        db, _make_user(db, email_suffix="c").id,
+        target_word_ids=target_ids,
+        used_spoken_word_ids=[],
+        turn_count=31,
+    )
+    complete, _ = check_completion(conv_31)
+    assert complete is True
+
+
+def test_check_completion_empty_targets_is_not_complete(db):
+    """Sanity: a conversation with no target_word_ids shouldn't auto-complete
+    on the word rule (empty set is trivially a subset). Hard limit still
+    applies, but at turn 0 we expect not-complete."""
+    user = _make_user(db)
+    _make_situation(db)
+    conv = _make_conversation(
+        db, user.id,
+        target_word_ids=[],
+        used_spoken_word_ids=[],
+        turn_count=0,
+    )
+    complete, turns_remaining = check_completion(conv)
+    assert complete is False
+    assert turns_remaining == EXCHANGE_WARNING_THRESHOLD


### PR DESCRIPTION
## Summary

First of 4 PRs implementing [backend #10](https://github.com/ericlaycock/SpanishForExpats_BE/issues/10) (realtime voice chat — ephemeral sessions + post-turn ingestion). This PR is Phase 1 only: extract the OpenAI Realtime session-config assembly into one shared module so Phase 0's new ephemeral endpoint and the legacy server-WS flow agree on model, voice, and system prompt.

**No behavior change.** The legacy `/voice-turn/respond` path keeps producing the exact same `session.update` payload it did before the refactor (verified by replaying the inline payload and diffing against `build_ws_session_update`).

## What changed

- **New** `app/services/realtime_config.py`:
  - `build_session_config(conversation, phase, db, *, alt_language, vocab_level, grammar_level, mode)` — full ephemeral config (for Phase 0's `POST /v1/realtime/sessions`) with `gpt-realtime-mini`, `server_vad` (threshold 0.5, 500ms), and `whisper-1` transcription. Also supports `mode=\"server_ws\"` for the legacy path.
  - `build_ws_session_update(voice, instructions, tts_instructions)` — low-level helper for `stream_realtime` which already has a pre-built message list.
  - `resolve_voice(animation_type, alt_language)` — wraps `SITUATION_VOICE_CONFIG` so voice/accent stays per-situation (agreed during planning — parity over the issue's generic `shimmer`).
- **Refactored** `app/services/realtime_service.py` to call `build_ws_session_update` instead of inlining the `session.update` dict.
- **Drive-by fix** in `app/models/__init__.py`: add `UserMilestoneEvent` to the package re-exports. It's defined in `app/models.py` but was never aliased in `__init__.py`, so `from app.models import UserMilestoneEvent` (used in `conversations.py:11`) fails on a cold Python process. Noticed while wiring up the test module; single line fix.

## Design notes

- Voice catalog (`SITUATION_VOICE_CONFIG`) still lives in `app/api/v1/conversations.py`. `realtime_config.resolve_voice` imports from there rather than duplicating. Moving the catalog to a neutral module is a natural follow-up but scope creep for this PR.
- `phase` is accepted by `build_session_config` per the issue spec. It's currently carried through for observability (no effect on the returned dict) — mirrors what the legacy `/voice-turn/respond` does with `X-Learning-Phase`. A test pins this so a future change that makes `phase` load-bearing has to update the test deliberately.
- `mode=\"ephemeral\"` vs `\"server_ws\"` branch: the two flows genuinely need different schemas (ephemeral needs `input_audio_transcription` + VAD; server_ws needs `output_audio_format: pcm16` because the server decodes to MP3). Keeping both in one builder means the shared fields (`model`, `voice`, `instructions`, `modalities`) can't drift.

## Tests

`tests/test_services/test_realtime_config.py`:
- Voice catalog lookups (banking/restaurant/unknown fallback, catalan/swedish accent swap).
- Ephemeral config shape (model + VAD + whisper + no `output_audio_format`).
- Grammar situation uses grammar prompt template.
- Alt-language swaps prompt language.
- Phase doesn't affect the dict (pinned).
- `server_ws` mode shape (no `model`, VAD disabled, pcm16 output).
- WS payload byte-identity with/without `tts_instructions`.

Conftest requires Postgres (UUID/JSONB). DB-less tests run and pass locally; DB tests run in CI.

## Test plan

- [ ] CI green (pytest against Postgres).
- [ ] Manual QA: hit `/voice-turn/respond` in QA with a banking, a restaurant, and a grammar conversation — voices and prompt behavior unchanged from pre-refactor.
- [ ] Confirm `app/main.py` cold-imports cleanly (drive-by fix verified).

## Rollout

No feature flag needed — this is a refactor behind the existing endpoint. Phases 0 / 2 / 3 will follow in separate PRs to keep review surface small.