### PR TITLE
Voice chat: sentence-hint endpoint + audit table

### DIFF
--- a/app/api/v1/conversations.py
+++ b/app/api/v1/conversations.py
@@ -17,6 +17,7 @@ from app.schemas import (
     MessageResponse,
     RealtimeTurnRequest,
     RealtimeTurnResponse,
+    SentenceHintResponse,
     VoiceTurnResponse,
     WordSchema
 )
@@ -1175,4 +1176,170 @@ async def realtime_turn(
         missing_word_ids=missing_word_ids,
         conversation_complete=complete,
         turns_remaining=turns_remaining,
+    )
+
+
+# ── "Need help?" sentence hint ────────────────────────────────────────
+# Avatar-side button on /voice-chat. Pulls the conversation's pending
+# items (vocab `word_*` or grammar `conj_<verb>_<pronoun>` candidates),
+# asks the LLM for ONE sentence the user could say next, TTS'es it with
+# the character voice, and audits the result. Capped per conversation
+# to keep cost predictable. Does NOT touch turn_count or
+# used_spoken_word_ids — see issue ericlaycock/SpanishForExpats_BE#12.
+
+class _SentenceHintRequest(_BaseModel):
+    # Optional: FE may pass the recent message log (same shape it uses
+    # for /voice-turn/respond) so the suggestion matches the live thread.
+    # When absent we fall back to "no prior turns" in the prompt.
+    messages_json: Optional[str] = None
+
+
+@router.post(
+    "/{conversation_id}/sentence-hint",
+    response_model=SentenceHintResponse,
+)
+async def sentence_hint(
+    conversation_id: str,
+    body: _SentenceHintRequest,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Generate one short Spanish sentence the learner could say next."""
+    import logging as _logging
+    from app.services.sentence_hint_service import (
+        SENTENCE_HINT_CAP_PER_CONVERSATION,
+        compute_pending_items,
+        generate_sentence_hint,
+        persist_hint_audit,
+        synthesize_hint_audio,
+    )
+    from app.core.logger import log_event
+
+    logger = _logging.getLogger(__name__)
+    request_id = getattr(request.state, "request_id", "unknown")
+    # Stringify so the request_logging middleware's JSON encoder doesn't
+    # choke when an HTTPException bubbles up before the success path.
+    request.state.user_id = str(current_user.id)
+
+    conversation = (
+        db.query(Conversation)
+        .filter(
+            Conversation.id == conversation_id,
+            Conversation.user_id == current_user.id,
+        )
+        .with_for_update()
+        .first()
+    )
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found"
+        )
+    if conversation.mode != "voice":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This endpoint is for voice mode only",
+        )
+    if conversation.status == "complete":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="NO_PENDING_ITEMS"
+        )
+
+    used = conversation.sentence_hints_used or 0
+    if used >= SENTENCE_HINT_CAP_PER_CONVERSATION:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="HINT_RATE_LIMIT",
+        )
+
+    alt_language = current_user.alt_language
+    pending_items = compute_pending_items(db, conversation, alt_language)
+    if not pending_items:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="NO_PENDING_ITEMS"
+        )
+
+    recent_messages = None
+    if body.messages_json:
+        try:
+            recent_messages = json_module.loads(body.messages_json)
+            if not isinstance(recent_messages, list):
+                recent_messages = None
+        except (json_module.JSONDecodeError, TypeError):
+            recent_messages = None
+
+    situation = (
+        db.query(Situation)
+        .filter(Situation.id == conversation.situation_id)
+        .first()
+    )
+
+    spanish, english_gloss, used_item_ids, llm_request_id = await generate_sentence_hint(
+        db,
+        user_id=str(current_user.id),
+        request_id=request_id,
+        pending_items=pending_items,
+        recent_messages=recent_messages,
+        situation_title=situation.title if situation else None,
+        alt_language=alt_language,
+    )
+
+    tts_voice, tts_instructions = get_tts_instructions(
+        situation.animation_type if situation else "",
+        alt_language=alt_language,
+        situation_id=situation.id if situation else None,
+    )
+
+    audio_url, tts_request_id = await synthesize_hint_audio(
+        db,
+        text=spanish,
+        voice=tts_voice,
+        instructions=tts_instructions,
+        request_id=request_id,
+        user_id=str(current_user.id),
+    )
+
+    # Increment + audit + commit. The cap check above already locked the
+    # conversation row via with_for_update so two parallel hint requests
+    # serialize through the increment cleanly.
+    conversation.sentence_hints_used = used + 1
+    persist_hint_audit(
+        db,
+        conversation=conversation,
+        user_id=current_user.id,
+        spanish=spanish,
+        english_gloss=english_gloss,
+        audio_url=audio_url,
+        used_item_ids=used_item_ids,
+        pending_count=len(pending_items),
+        llm_request_id=llm_request_id,
+        tts_request_id=tts_request_id,
+    )
+    db.commit()
+
+    log_event(
+        level="info",
+        event="sentence_hint_used",
+        message=f"Sentence hint generated for conversation {conversation_id}",
+        request_id=request_id,
+        user_id=str(current_user.id),
+        extra={
+            "conversation_id": str(conversation.id),
+            "situation_id": conversation.situation_id,
+            "pending_count": len(pending_items),
+            "used_item_ids": used_item_ids,
+            "hints_used": conversation.sentence_hints_used,
+            "audio_uploaded": audio_url is not None,
+        },
+    )
+
+    hints_remaining = max(
+        0, SENTENCE_HINT_CAP_PER_CONVERSATION - conversation.sentence_hints_used
+    )
+    return SentenceHintResponse(
+        spanish=spanish,
+        english_gloss=english_gloss,
+        audio_url=audio_url,
+        used_item_ids=used_item_ids,
+        hints_remaining=hints_remaining,
     )

--- a/app/models.py
+++ b/app/models.py
@@ -185,6 +185,9 @@ class Conversation(Base):
     # limit in check_completion even when the backend isn't orchestrating each
     # round-trip. Migration 020 adds it with default 0.
     turn_count = Column(Integer, default=0, nullable=False, server_default="0")
+    # Per-conversation counter for "Need help?" sentence hints. Capped by
+    # sentence_hint_service to prevent farming. Migration 026.
+    sentence_hints_used = Column(Integer, default=0, nullable=False, server_default="0")
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
     completed_at = Column(DateTime(timezone=True), nullable=True)
@@ -298,5 +301,47 @@ class UserMilestoneEvent(Base):
     situation_id = Column(String, ForeignKey("situations.id"), nullable=True)
     conversation_id = Column(UUID(as_uuid=True), ForeignKey("conversations.id"), nullable=True)
     occurred_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class SentenceHint(Base):
+    """Audit row for each sentence hint generated in /voice-chat.
+
+    Migration 026 introduces this table alongside `conversations.sentence_hints_used`.
+    The counter on `conversations` enforces the per-encounter cap; this table
+    keeps the human-readable artefacts (Spanish + gloss + audio URL) plus
+    pointers back to the LLM/TTS rows so we can replay or investigate later.
+    """
+    __tablename__ = "sentence_hints"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    conversation_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    situation_id = Column(String, ForeignKey("situations.id"), nullable=True)
+    spanish = Column(Text, nullable=False)
+    english_gloss = Column(Text, nullable=False)
+    audio_url = Column(Text, nullable=True)
+    used_item_ids = Column(JSONB, default=list, nullable=False, server_default="[]")
+    pending_count = Column(Integer, nullable=True)
+    llm_request_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("llm_requests.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    tts_request_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("tts_requests.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -27,6 +27,7 @@ DailyEncounterLog = models_legacy.DailyEncounterLog
 UserReport = models_legacy.UserReport
 UserMilestoneEvent = models_legacy.UserMilestoneEvent
 Grenade = models_legacy.Grenade
+SentenceHint = models_legacy.SentenceHint
 REPORT_CATEGORIES = models_legacy.REPORT_CATEGORIES
 REPORT_STATUSES = models_legacy.REPORT_STATUSES
 # Base is imported from database, not from models.py
@@ -52,6 +53,7 @@ __all__ = [
     "UserReport",
     "UserMilestoneEvent",
     "Grenade",
+    "SentenceHint",
     "REPORT_CATEGORIES",
     "REPORT_STATUSES",
     "LLMRequest",

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -287,6 +287,19 @@ class VoiceTurnResponse(BaseModel):
     conversation_complete: bool
 
 
+# "Need help?" hint generated on demand from /voice-chat. The avatar
+# renders `spanish` in its bubble, `english_gloss` as the translation,
+# and uses `audio_url` for the Listen affordance. `used_item_ids` is
+# what the LLM claims it used — vocab `word_*` ids and/or grammar
+# `conj_<verb>_<pronoun>` chip ids — surfaced for telemetry only.
+class SentenceHintResponse(BaseModel):
+    spanish: str
+    english_gloss: str
+    audio_url: Optional[str] = None
+    used_item_ids: List[str]
+    hints_remaining: int
+
+
 # Realtime (WebRTC) session schemas
 # Minted by POST /v1/realtime/sessions — the browser trades this client_secret
 # for a direct OpenAI Realtime WebRTC connection. Backend never relays audio.

--- a/app/services/llm_gateway.py
+++ b/app/services/llm_gateway.py
@@ -210,6 +210,7 @@ async def generate_conversation(
             "tokens_out": tokens_out,
             "latency_ms": latency_ms,
             "estimated_cost": estimated_cost,
+            "llm_request_id": str(llm_record.id),
         }
         
     except Exception as e:

--- a/app/services/sentence_hint_service.py
+++ b/app/services/sentence_hint_service.py
@@ -1,0 +1,407 @@
+"""Sentence-hint generation for the /voice-chat "Need help?" button.
+
+The FE asks the BE for a single short Spanish sentence the learner could
+say next, using 1 or 2 items they haven't completed yet (vocab words for
+non-grammar encounters, conjugation chips for grammar encounters). The
+result is rendered in the avatar's speech bubble; the FE owns the
+display.
+
+Per-conversation cap (5 hints) lives on the conversation row
+(`sentence_hints_used`); this module is concerned with assembling the
+candidate item list, calling the LLM, synthesizing TTS, and persisting
+the audit row in `sentence_hints`. The endpoint orchestrates the cap
+check, the increment, and the response shape.
+
+Grammar nuance: BE doesn't know which specific `(verb, pronoun)` chips
+the user has already ticked — only the FE does, since detection happens
+on the conjugated form. We therefore expose ALL drill_targets whose
+verb is still in `missing_word_ids` (i.e., the infinitive isn't mastered
+in this conversation yet) and let the LLM pick 1–2. Worst case the model
+suggests a (verb, pronoun) chip the user already said; we never suggest
+items for an already-mastered verb.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.models import Conversation, SentenceHint
+from app.services.alt_language_service import (
+    apply_alt_language,
+    get_target_language_name,
+)
+from app.services.conversation_service import get_missing_word_ids
+from app.services.llm_gateway import ConversationContext, generate_conversation
+from app.services.openai_media_gateway import synthesize_speech as gateway_synthesize_speech
+from app.services.word_detection import get_words_by_ids
+from app.utils.audio import generate_audio_filename, get_audio_path, upload_to_r2
+
+logger = logging.getLogger(__name__)
+
+
+# Cap enforced at the endpoint; surfaced here for tests to import.
+SENTENCE_HINT_CAP_PER_CONVERSATION = 5
+
+# Anything beyond this many candidate items gets truncated to keep the
+# prompt small and the LLM focused. The cap is generous enough to cover
+# every realistic vocab + grammar encounter.
+MAX_CANDIDATE_ITEMS = 12
+
+
+@dataclass
+class PendingItem:
+    """Candidate item the LLM may use in the suggested sentence.
+
+    `kind` discriminates between vocab and grammar items; `id` is the FE
+    chip id (vocab `word_*` or grammar `conj_<verb>_<pronoun>`); the
+    optional fields are populated per-kind for the prompt.
+    """
+    kind: str  # "vocab" | "grammar"
+    id: str
+    spanish: str
+    english: str
+    # grammar-only
+    verb: Optional[str] = None
+    pronoun: Optional[str] = None
+    conjugated: Optional[str] = None
+
+
+def compute_pending_items(
+    db: Session,
+    conversation: Conversation,
+    alt_language: Optional[str],
+) -> List[PendingItem]:
+    """Build the candidate item list for the hint prompt.
+
+    Vocab path: take `missing_word_ids`, hydrate via `get_words_by_ids`,
+    apply alt-language swap so `spanish` reflects what the chip actually
+    shows (catalan/swedish swaps).
+
+    Grammar path: for each drill_target whose verb is still missing, emit
+    one candidate per `(verb, pronoun)` with the conjugated form pulled
+    from `drill_config.answers`.
+    """
+    from app.data.grammar_situations import (
+        GRAMMAR_WORD_TRANSLATIONS,
+        get_grammar_config,
+    )
+
+    grammar_cfg = get_grammar_config(conversation.situation_id)
+    if grammar_cfg and grammar_cfg.get("drill_targets"):
+        return _grammar_pending_items(conversation, grammar_cfg)
+
+    return _vocab_pending_items(db, conversation, alt_language)
+
+
+def _vocab_pending_items(
+    db: Session,
+    conversation: Conversation,
+    alt_language: Optional[str],
+) -> List[PendingItem]:
+    missing_ids = get_missing_word_ids(conversation, "voice")
+    if not missing_ids:
+        return []
+    words = get_words_by_ids(db, missing_ids)
+    words = apply_alt_language(words, alt_language, db)
+    return [
+        PendingItem(
+            kind="vocab",
+            id=w.id,
+            spanish=w.spanish,
+            english=w.english,
+        )
+        for w in words
+    ]
+
+
+def _grammar_pending_items(
+    conversation: Conversation,
+    grammar_cfg: Dict[str, Any],
+) -> List[PendingItem]:
+    from app.data.grammar_situations import GRAMMAR_WORD_TRANSLATIONS
+
+    answers = (grammar_cfg.get("drill_config") or {}).get("answers") or {}
+    drill_targets = grammar_cfg.get("drill_targets") or []
+
+    used = set(conversation.used_spoken_word_ids or [])
+    target_ids = set(conversation.target_word_ids or [])
+    # A verb is "still pending" if its base id is in target_word_ids and
+    # not yet in used_spoken_word_ids. This mirrors the FE's chip state
+    # at the verb level — granularity per (verb, pronoun) lives only on
+    # the FE; see module docstring.
+    items: List[PendingItem] = []
+    for t in drill_targets:
+        verb = t.get("verb")
+        pronoun = t.get("pronoun")
+        if not verb or not pronoun:
+            continue
+        base_id = f"grammar_{verb}"
+        if base_id not in target_ids:
+            continue
+        if base_id in used:
+            continue
+        conjugated = (answers.get(verb) or {}).get(pronoun)
+        if not conjugated:
+            continue
+        items.append(
+            PendingItem(
+                kind="grammar",
+                id=f"conj_{verb}_{pronoun}",
+                spanish=conjugated,
+                english=GRAMMAR_WORD_TRANSLATIONS.get(verb, verb),
+                verb=verb,
+                pronoun=pronoun,
+                conjugated=conjugated,
+            )
+        )
+    return items
+
+
+def build_hint_messages(
+    pending_items: List[PendingItem],
+    recent_messages: Optional[List[Dict[str, str]]],
+    situation_title: Optional[str],
+    alt_language: Optional[str],
+) -> List[Dict[str, str]]:
+    """Build the LLM messages for hint generation.
+
+    Returns a `messages` list ready for `ConversationContext`. Includes a
+    system prompt with formatting rules and a user prompt with the
+    pending items + the last 4 turns of conversation context.
+    """
+    target_language = get_target_language_name(alt_language)
+    items_block = _format_items_for_prompt(pending_items)
+
+    history_block = _format_history_for_prompt(recent_messages or [])
+
+    title = situation_title or "this conversation"
+
+    system = (
+        f"You are a {target_language} tutor helping a learner finish a sentence "
+        "in a live roleplay conversation. Generate ONE short sentence "
+        "(≤12 words) the LEARNER could naturally say NEXT, using 1 or 2 of the "
+        "pending items provided.\n\n"
+        "Rules:\n"
+        "- Write in first person — the LEARNER is the speaker.\n"
+        "- Match the register/tone of the last assistant turn (formal vs informal).\n"
+        f"- For grammar items, use the EXACT conjugated form from the item list. "
+        f"Do not substitute another tense, person, or verb.\n"
+        f"- Keep the sentence natural — the goal is something a real speaker would say.\n"
+        "- Do not greet, do not summarize, do not narrate.\n\n"
+        "Return ONLY valid JSON with this exact shape:\n"
+        '{"spanish": "<the sentence>", "english_gloss": "<English translation>", '
+        '"used_item_ids": ["<id from pending items>"]}'
+    )
+
+    user = (
+        f"Scenario: {title}\n\n"
+        f"Pending items the learner still needs to use:\n{items_block}\n\n"
+        f"Recent turns:\n{history_block}\n\n"
+        "Suggest the learner's next sentence."
+    )
+
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+
+
+def _format_items_for_prompt(items: List[PendingItem]) -> str:
+    if not items:
+        return "(none)"
+    lines = []
+    for it in items[:MAX_CANDIDATE_ITEMS]:
+        if it.kind == "grammar":
+            lines.append(
+                f"- {it.id}: \"{it.conjugated}\"  ({it.pronoun} + {it.verb} = \"{it.english}\")"
+            )
+        else:
+            lines.append(f"- {it.id}: \"{it.spanish}\"  ({it.english})")
+    return "\n".join(lines)
+
+
+def _format_history_for_prompt(messages: List[Dict[str, str]]) -> str:
+    """Render the last 4 non-system turns for the prompt context."""
+    trimmed = [m for m in messages if m.get("role") != "system"][-4:]
+    if not trimmed:
+        return "(no prior turns)"
+    return "\n".join(
+        f"[{m.get('role', 'unknown')}] {m.get('content', '')}" for m in trimmed
+    )
+
+
+async def generate_sentence_hint(
+    db: Session,
+    *,
+    user_id: str,
+    request_id: str,
+    pending_items: List[PendingItem],
+    recent_messages: Optional[List[Dict[str, str]]],
+    situation_title: Optional[str],
+    alt_language: Optional[str],
+) -> Tuple[str, str, List[str], Optional[str]]:
+    """Call the LLM to produce a hint sentence. Returns (spanish,
+    english_gloss, used_item_ids, llm_request_id).
+
+    The `llm_request_id` is the `id` of the persisted `LLMRequest` row
+    so the caller can attach it to the `sentence_hints` audit row.
+    Falls back to a defensive item-pair-only sentence if the LLM
+    returns malformed JSON; the upstream handler raises if items are
+    empty so we never ship "(none)" to the user.
+    """
+    messages = build_hint_messages(
+        pending_items, recent_messages, situation_title, alt_language
+    )
+
+    context = ConversationContext(
+        request_id=request_id,
+        user_id=user_id,
+        system_prompt="",  # overridden by `messages` below
+        user_prompt="",
+        agent_id="sentence_hint",
+        prompt_version="v1",
+        messages=messages,
+        return_json=True,
+        max_tokens=200,
+    )
+
+    result = await generate_conversation(context, db)
+    content = result.get("content") if isinstance(result, dict) else None
+    llm_request_id = result.get("llm_request_id") if isinstance(result, dict) else None
+
+    spanish, english_gloss, used_item_ids = _parse_hint_payload(content, pending_items)
+    return spanish, english_gloss, used_item_ids, llm_request_id
+
+
+def _parse_hint_payload(
+    content: Any,
+    pending_items: List[PendingItem],
+) -> Tuple[str, str, List[str]]:
+    """Coerce the LLM payload into (spanish, english_gloss, used_item_ids).
+
+    The Responses API returns dict directly when `return_json=True`. If
+    the model misbehaves and returns a string, we try one JSON parse
+    pass; otherwise we fall back to the first pending item (so the user
+    always gets something usable instead of a 500).
+    """
+    payload: Dict[str, Any] = {}
+    if isinstance(content, dict):
+        payload = content
+    elif isinstance(content, str):
+        try:
+            payload = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+
+    spanish = (payload.get("spanish") or "").strip()
+    english_gloss = (payload.get("english_gloss") or "").strip()
+    used_raw = payload.get("used_item_ids") or []
+    if not isinstance(used_raw, list):
+        used_raw = []
+
+    valid_ids = {it.id for it in pending_items}
+    used_item_ids = [str(i) for i in used_raw if str(i) in valid_ids]
+
+    if not spanish or not english_gloss:
+        # Fall back to the first pending item so we never ship empty
+        # text to the FE. Keeps the UI honest if the model misfires.
+        if pending_items:
+            it = pending_items[0]
+            spanish = it.spanish if not spanish else spanish
+            english_gloss = it.english if not english_gloss else english_gloss
+            if not used_item_ids:
+                used_item_ids = [it.id]
+
+    return spanish, english_gloss, used_item_ids
+
+
+async def synthesize_hint_audio(
+    db: Session,
+    *,
+    text: str,
+    voice: str,
+    instructions: Optional[str],
+    request_id: str,
+    user_id: str,
+) -> Tuple[Optional[str], Optional[str]]:
+    """TTS the hint sentence and upload to R2. Returns (audio_url,
+    tts_request_id). Either may be None if TTS or upload fails — the
+    endpoint must handle that gracefully (FE shows text only).
+    """
+    filename = f"hint_{generate_audio_filename()}"
+    output_path = str(get_audio_path(filename))
+
+    try:
+        # `gateway_synthesize_speech` writes the file and inserts a
+        # `tts_requests` row. We pull the row id back via the latest
+        # successful insert in the session — gateway doesn't return it
+        # today and threading through would cascade to every caller.
+        await gateway_synthesize_speech(
+            text=text,
+            output_path=output_path,
+            voice=voice,
+            instructions=instructions,
+            request_id=request_id,
+            user_id=user_id,
+            db=db,
+            learning_phase="hint",
+        )
+    except Exception as e:
+        logger.error(f"[SentenceHint] TTS failed: {e}")
+        return None, None
+
+    audio_url = upload_to_r2(output_path, filename)
+    tts_request_id = _latest_tts_request_id(db, request_id)
+    return audio_url, tts_request_id
+
+
+def _latest_tts_request_id(db: Session, request_id: str) -> Optional[str]:
+    """Look up the TTSRequest row this gateway call just persisted.
+
+    Matched by `request_id` (the per-call correlation id) ordered by
+    `created_at DESC`. Returns the UUID as a string for the audit row.
+    """
+    from app.models import TTSRequest
+
+    row = (
+        db.query(TTSRequest)
+        .filter(TTSRequest.request_id == request_id)
+        .order_by(TTSRequest.created_at.desc())
+        .first()
+    )
+    return str(row.id) if row else None
+
+
+def persist_hint_audit(
+    db: Session,
+    *,
+    conversation: Conversation,
+    user_id: str,
+    spanish: str,
+    english_gloss: str,
+    audio_url: Optional[str],
+    used_item_ids: List[str],
+    pending_count: int,
+    llm_request_id: Optional[str],
+    tts_request_id: Optional[str],
+) -> SentenceHint:
+    """Insert the audit row. Caller is responsible for the commit."""
+    row = SentenceHint(
+        conversation_id=conversation.id,
+        user_id=user_id,
+        situation_id=conversation.situation_id,
+        spanish=spanish,
+        english_gloss=english_gloss,
+        audio_url=audio_url,
+        used_item_ids=used_item_ids,
+        pending_count=pending_count,
+        llm_request_id=llm_request_id,
+        tts_request_id=tts_request_id,
+    )
+    db.add(row)
+    db.flush()
+    return row

--- a/migrations/versions/026_add_sentence_hints.py
+++ b/migrations/versions/026_add_sentence_hints.py
@@ -1,0 +1,110 @@
+"""Add sentence_hints table and sentence_hints_used counter
+
+Revision ID: 026_sentence_hints
+Revises: 025_sub_lifecycle_explainers
+Create Date: 2026-04-29
+
+Backs the "Need help?" feature in /voice-chat. The conversation gets a
+counter (`sentence_hints_used`) to enforce the per-encounter cap, and
+every generated hint is persisted to `sentence_hints` for analytics —
+text, English gloss, the items the model claimed to use, and pointers
+back to the LLM/TTS rows so we can replay or investigate later.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+
+revision = "026_sentence_hints"
+down_revision = "025_sub_lifecycle_explainers"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "sentence_hints_used",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+    op.create_table(
+        "sentence_hints",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "conversation_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("conversations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "situation_id",
+            sa.String(),
+            sa.ForeignKey("situations.id"),
+            nullable=True,
+        ),
+        sa.Column("spanish", sa.Text(), nullable=False),
+        sa.Column("english_gloss", sa.Text(), nullable=False),
+        sa.Column("audio_url", sa.Text(), nullable=True),
+        sa.Column(
+            "used_item_ids",
+            JSONB(),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("pending_count", sa.Integer(), nullable=True),
+        sa.Column(
+            "llm_request_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("llm_requests.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "tts_request_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("tts_requests.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_sentence_hints_conversation_id",
+        "sentence_hints",
+        ["conversation_id"],
+    )
+    op.create_index(
+        "ix_sentence_hints_user_id",
+        "sentence_hints",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_sentence_hints_created_at",
+        "sentence_hints",
+        [sa.text("created_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sentence_hints_created_at", table_name="sentence_hints")
+    op.drop_index("ix_sentence_hints_user_id", table_name="sentence_hints")
+    op.drop_index(
+        "ix_sentence_hints_conversation_id", table_name="sentence_hints"
+    )
+    op.drop_table("sentence_hints")
+    op.drop_column("conversations", "sentence_hints_used")

--- a/tests/test_sentence_hint.py
+++ b/tests/test_sentence_hint.py
@@ -1,0 +1,381 @@
+"""HTTP-level tests for POST /v1/conversations/{id}/sentence-hint.
+
+Covers:
+- Happy path (vocab): 200 with spanish, english_gloss, audio_url, used_item_ids
+  and hints_remaining decremented by 1.
+- Grammar path: pending items walk drill_targets and the LLM is fed conjugated
+  forms it can pick from.
+- Cap: 5th hint succeeds, 6th returns 429 HINT_RATE_LIMIT.
+- 409 NO_PENDING_ITEMS when every target word is already detected.
+- 409 NO_PENDING_ITEMS when conversation status is already "complete".
+- 404 when the conversation belongs to another user (or doesn't exist).
+- turn_count is NOT incremented by hints — they are help, not progress.
+- Audit row in `sentence_hints` carries the artefact text + pending_count.
+- TTS failure: endpoint still returns the hint with audio_url=None.
+
+All upstream calls (LLM, TTS, R2 upload) are monkeypatched. DB work runs
+against the Postgres test instance via tests/conftest.py.
+"""
+import uuid
+
+import pytest
+
+from app.models import Conversation, SentenceHint, Situation, Word
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _get_auth_user_id(headers):
+    from jose import jwt
+    token = headers["Authorization"].split()[1]
+    payload = jwt.get_unverified_claims(token)
+    return uuid.UUID(payload["sub"])
+
+
+def _seed_vocab_situation(db):
+    sit = Situation(
+        id="bank_hint",
+        title="Open a Bank Account",
+        animation_type="banking",
+        encounter_number=1,
+        order_index=1,
+        is_free=True,
+    )
+    db.add(sit)
+    db.add_all([
+        Word(id="word_cuenta", spanish="cuenta", english="account", word_category="encounter"),
+        Word(id="word_depositar", spanish="depositar", english="to deposit", word_category="encounter"),
+        Word(id="word_pasaporte", spanish="pasaporte", english="passport", word_category="high_frequency"),
+    ])
+    db.flush()
+    return sit
+
+
+def _seed_grammar_situation(db):
+    """Use an existing grammar situation id from grammar_situations.py so
+    `get_grammar_config` resolves and returns drill_targets.
+    """
+    sit = Situation(
+        id="grammar_regular_present_1",
+        title="Regular Present (1/3)",
+        animation_type="grammar",
+        encounter_number=300,
+        order_index=1300,
+        is_free=True,
+        situation_type="grammar",
+    )
+    db.add(sit)
+    db.add_all([
+        Word(id="grammar_hablar", spanish="hablar", english="to speak", word_category="grammar"),
+        Word(id="grammar_beber", spanish="beber", english="to drink", word_category="grammar"),
+        Word(id="grammar_vivir", spanish="vivir", english="to live", word_category="grammar"),
+    ])
+    db.flush()
+    return sit
+
+
+def _make_voice_conv(db, user_id, situation_id, target_word_ids, used=None):
+    conv = Conversation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        situation_id=situation_id,
+        mode="voice",
+        target_word_ids=target_word_ids,
+        used_typed_word_ids=[],
+        used_spoken_word_ids=used or [],
+        status="active",
+    )
+    db.add(conv)
+    db.flush()
+    return conv
+
+
+def _stub_llm_and_tts(monkeypatch, *, spanish="Quiero abrir una cuenta.",
+                      english_gloss="I want to open an account.",
+                      used_item_ids=None,
+                      audio_url="https://r2.example/hint_test.mp3"):
+    """Wire the service to deterministic LLM/TTS responses.
+
+    `llm_request_id` and `tts_request_id` are returned as None so tests
+    don't need to seed those gateway tables — the audit row's FKs are
+    nullable for exactly this reason. Production paths will populate them.
+    """
+    from app.services import sentence_hint_service as svc
+
+    async def fake_generate_conversation(context, db):
+        return {
+            "content": {
+                "spanish": spanish,
+                "english_gloss": english_gloss,
+                "used_item_ids": used_item_ids or [],
+            },
+            "tokens_in": 100,
+            "tokens_out": 30,
+            "latency_ms": 400,
+            "estimated_cost": 0.0001,
+            "llm_request_id": None,
+        }
+
+    async def fake_synthesize(db, *, text, voice, instructions, request_id, user_id):
+        return audio_url, None
+
+    monkeypatch.setattr(svc, "generate_conversation", fake_generate_conversation)
+    monkeypatch.setattr(svc, "synthesize_hint_audio", fake_synthesize)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+
+def test_sentence_hint_vocab_happy_path(client, db, auth_user, monkeypatch):
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_vocab_situation(db)
+    conv = _make_voice_conv(
+        db, user_id, "bank_hint",
+        target_word_ids=["word_cuenta", "word_depositar", "word_pasaporte"],
+    )
+    db.commit()
+
+    _stub_llm_and_tts(
+        monkeypatch,
+        spanish="Quiero abrir una cuenta.",
+        english_gloss="I want to open an account.",
+        used_item_ids=["word_cuenta"],
+    )
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/sentence-hint",
+        json={},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["spanish"] == "Quiero abrir una cuenta."
+    assert body["english_gloss"] == "I want to open an account."
+    assert body["audio_url"] == "https://r2.example/hint_test.mp3"
+    assert body["used_item_ids"] == ["word_cuenta"]
+    assert body["hints_remaining"] == 4
+
+    db.refresh(conv)
+    assert conv.sentence_hints_used == 1
+    assert conv.turn_count == 0  # hints don't advance turns
+
+    # Audit row persisted with the same artefacts
+    audit = db.query(SentenceHint).filter_by(conversation_id=conv.id).one()
+    assert audit.spanish == "Quiero abrir una cuenta."
+    assert audit.english_gloss == "I want to open an account."
+    assert audit.audio_url == "https://r2.example/hint_test.mp3"
+    assert audit.used_item_ids == ["word_cuenta"]
+    assert audit.pending_count == 3
+    assert audit.user_id == user_id
+    assert audit.situation_id == "bank_hint"
+
+
+def test_sentence_hint_grammar_emits_conjugation_candidates(
+    client, db, auth_user, monkeypatch
+):
+    """For a grammar conversation, the LLM should be fed conj_<verb>_<pronoun>
+    candidates pulled from drill_targets + drill_config.answers.
+    """
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_grammar_situation(db)
+    conv = _make_voice_conv(
+        db, user_id, "grammar_regular_present_1",
+        target_word_ids=["grammar_hablar", "grammar_beber", "grammar_vivir"],
+    )
+    db.commit()
+
+    captured = {}
+    from app.services import sentence_hint_service as svc
+
+    real_build = svc.build_hint_messages
+
+    def spy_build(pending_items, recent_messages, situation_title, alt_language):
+        captured["items"] = list(pending_items)
+        return real_build(pending_items, recent_messages, situation_title, alt_language)
+
+    monkeypatch.setattr(svc, "build_hint_messages", spy_build)
+    _stub_llm_and_tts(
+        monkeypatch,
+        spanish="Yo hablo inglés.",
+        english_gloss="I speak English.",
+        used_item_ids=["conj_hablar_yo"],
+    )
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/sentence-hint",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    items = captured["items"]
+    assert items, "Expected pending items for a grammar conversation"
+    assert all(it.kind == "grammar" for it in items)
+    # Conjugated forms come from drill_config.answers — sanity-check one.
+    pairs = {(it.verb, it.pronoun): it.conjugated for it in items}
+    assert pairs.get(("hablar", "yo")) == "hablo"
+    assert all(
+        it.id == f"conj_{it.verb}_{it.pronoun}" for it in items
+    )
+
+
+def test_sentence_hint_cap_blocks_sixth(client, db, auth_user, monkeypatch):
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_vocab_situation(db)
+    conv = _make_voice_conv(
+        db, user_id, "bank_hint",
+        target_word_ids=["word_cuenta", "word_depositar"],
+    )
+    conv.sentence_hints_used = 5
+    db.commit()
+
+    _stub_llm_and_tts(monkeypatch)
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/sentence-hint",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == 429
+    assert resp.json()["detail"] == "HINT_RATE_LIMIT"
+
+
+def test_sentence_hint_409_when_all_words_detected(
+    client, db, auth_user, monkeypatch
+):
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_vocab_situation(db)
+    conv = _make_voice_conv(
+        db, user_id, "bank_hint",
+        target_word_ids=["word_cuenta", "word_depositar"],
+        used=["word_cuenta", "word_depositar"],
+    )
+    db.commit()
+    _stub_llm_and_tts(monkeypatch)
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/sentence-hint",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "NO_PENDING_ITEMS"
+
+
+def test_sentence_hint_409_when_conversation_complete(
+    client, db, auth_user, monkeypatch
+):
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_vocab_situation(db)
+    conv = _make_voice_conv(
+        db, user_id, "bank_hint",
+        target_word_ids=["word_cuenta"],
+    )
+    conv.status = "complete"
+    db.commit()
+    _stub_llm_and_tts(monkeypatch)
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/sentence-hint",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "NO_PENDING_ITEMS"
+
+
+def test_sentence_hint_404_when_owned_by_other_user(
+    client, db, auth_user, monkeypatch
+):
+    _, headers = auth_user
+    _seed_vocab_situation(db)
+    # Register a second real user so the conversations FK to users.id holds.
+    from tests.conftest import register_user
+    other_data, _ = register_user(client, email="other@example.com")
+    other_user_id = uuid.UUID(other_data["user_id"])
+    conv = _make_voice_conv(
+        db, other_user_id, "bank_hint",
+        target_word_ids=["word_cuenta"],
+    )
+    db.commit()
+    _stub_llm_and_tts(monkeypatch)
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/sentence-hint",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_sentence_hint_audio_failure_returns_text_only(
+    client, db, auth_user, monkeypatch
+):
+    """If TTS or the R2 upload fails, the endpoint still returns the hint
+    with audio_url=None. The avatar bubble shows the text without the
+    Listen affordance.
+    """
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_vocab_situation(db)
+    conv = _make_voice_conv(
+        db, user_id, "bank_hint",
+        target_word_ids=["word_cuenta"],
+    )
+    db.commit()
+
+    _stub_llm_and_tts(
+        monkeypatch,
+        spanish="Quiero una cuenta.",
+        english_gloss="I want an account.",
+        used_item_ids=["word_cuenta"],
+        audio_url=None,
+    )
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/sentence-hint",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["spanish"] == "Quiero una cuenta."
+    assert body["audio_url"] is None
+    assert body["hints_remaining"] == 4
+
+    db.refresh(conv)
+    assert conv.sentence_hints_used == 1
+
+
+def test_sentence_hint_does_not_change_turn_count(
+    client, db, auth_user, monkeypatch
+):
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_vocab_situation(db)
+    conv = _make_voice_conv(
+        db, user_id, "bank_hint",
+        target_word_ids=["word_cuenta", "word_depositar"],
+    )
+    conv.turn_count = 7
+    db.commit()
+    _stub_llm_and_tts(monkeypatch)
+
+    for _ in range(3):
+        resp = client.post(
+            f"/v1/conversations/{conv.id}/sentence-hint",
+            json={},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+    db.refresh(conv)
+    assert conv.turn_count == 7
+    assert conv.sentence_hints_used == 3


### PR DESCRIPTION
## Summary
Implements the BE half of the `/voice-chat` "Need help?" button (issue #12). The frontend will POST to `/v1/conversations/{id}/sentence-hint`; the backend generates one short Spanish sentence the learner could say next, using 1–2 items they haven't completed yet, TTSes it with the character's voice, and persists an audit row.

## What's in
- **Migration 026** — adds `conversations.sentence_hints_used` (per-encounter counter) and a new `sentence_hints` table (id, conversation_id CASCADE, user_id SET NULL, situation_id, spanish, english_gloss, audio_url, used_item_ids JSONB, pending_count, llm_request_id, tts_request_id, created_at). Indexed on conversation_id, user_id, and created_at DESC.
- **`SentenceHint` model** + `Conversation.sentence_hints_used` column.
- **`SentenceHintResponse`** Pydantic model: `spanish`, `english_gloss`, `audio_url`, `used_item_ids`, `hints_remaining`.
- **`app/services/sentence_hint_service.py`** — pending-item computation (vocab via `get_missing_word_ids`; grammar walks `drill_targets` for any verb still missing in `used_spoken_word_ids` and emits `conj_<verb>_<pronoun>` candidates with conjugated forms from `drill_config.answers`), prompt builder, LLM call (`return_json=True`), TTS via `gateway_synthesize_speech` + R2 upload, audit row insert.
- **`POST /v1/conversations/{id}/sentence-hint`** in `conversations.py`:
  - 404 if not owned by user, 400 if not voice mode.
  - 409 `NO_PENDING_ITEMS` when conversation is complete or has no pending items.
  - 429 `HINT_RATE_LIMIT` when `sentence_hints_used >= 5`.
  - Increments counter + persists audit + commits in one transaction (lock via `with_for_update()`).
  - Does **not** increment `turn_count` or touch `used_spoken_word_ids`.
  - Reuses `get_tts_instructions` so the character voice carries through (including grammar chats mapped via `GRAMMAR_SCENE_MAP`).
- **`generate_conversation`** now returns `llm_request_id` alongside `content` so the audit row can FK to it.

## Tests (8/8 passing locally)
- `test_sentence_hint_vocab_happy_path` — 200 with all fields, `hints_remaining` decrements, audit row written, `turn_count` unchanged.
- `test_sentence_hint_grammar_emits_conjugation_candidates` — pending items contain `conj_<verb>_<pronoun>` entries with the conjugated form from `drill_config.answers`.
- `test_sentence_hint_cap_blocks_sixth` — 5th OK, 6th → 429.
- `test_sentence_hint_409_when_all_words_detected` and `test_sentence_hint_409_when_conversation_complete`.
- `test_sentence_hint_404_when_owned_by_other_user`.
- `test_sentence_hint_audio_failure_returns_text_only` — endpoint returns `audio_url: null` when TTS fails; FE renders text-only.
- `test_sentence_hint_does_not_change_turn_count`.

The 4xx tests in `test_realtime.py` / `test_realtime_turn.py` fail with the same `UUID is not JSON serializable` error on plain `qa` — pre-existing middleware bug, not introduced here.

## Out of scope (FE)
The matching frontend issue is `ericlaycock/SpanishForExpats_FE#75`; FE PR will land separately on top of this.

## Test plan
- [ ] Apply migration on QA: `alembic upgrade head` (or auto-migrate on deploy).
- [ ] Hit the endpoint from the FE branch — verify 200 path returns Spanish + English + audio_url.
- [ ] Verify `sentence_hints_used` increments and 6th call returns 429.
- [ ] Verify `sentence_hints` row contains the artefact text + `pending_count`.
- [ ] Trigger a grammar conversation — verify the LLM uses one of the conjugated forms (not the infinitive).