### PR TITLE
Sentence hint: graceful fallback when LLM returns empty output_text

### DIFF
--- a/app/services/sentence_hint_service.py
+++ b/app/services/sentence_hint_service.py
@@ -269,9 +269,23 @@ async def generate_sentence_hint(
         max_tokens=200,
     )
 
-    result = await generate_conversation(context, db)
-    content = result.get("content") if isinstance(result, dict) else None
-    llm_request_id = result.get("llm_request_id") if isinstance(result, dict) else None
+    # gpt-5.4-mini's Responses API + reasoning: low + return_json
+    # occasionally hands back an empty `output_text` (the LLM gateway
+    # then chokes on `json.loads("")`). Treat any failure here as
+    # "model didn't produce parseable output" and let the parser fall
+    # back to a first-pending-item suggestion — better than 500'ing the
+    # user out of the encounter.
+    content: Any = None
+    llm_request_id: Optional[str] = None
+    try:
+        result = await generate_conversation(context, db)
+        if isinstance(result, dict):
+            content = result.get("content")
+            llm_request_id = result.get("llm_request_id")
+    except json.JSONDecodeError as e:
+        logger.warning(f"[SentenceHint] LLM returned unparseable JSON: {e}")
+    except Exception as e:
+        logger.warning(f"[SentenceHint] LLM call failed: {type(e).__name__}: {e}")
 
     spanish, english_gloss, used_item_ids = _parse_hint_payload(content, pending_items)
     return spanish, english_gloss, used_item_ids, llm_request_id

--- a/tests/test_sentence_hint.py
+++ b/tests/test_sentence_hint.py
@@ -354,6 +354,56 @@ def test_sentence_hint_audio_failure_returns_text_only(
     assert conv.sentence_hints_used == 1
 
 
+def test_sentence_hint_falls_back_when_llm_returns_unparseable_json(
+    client, db, auth_user, monkeypatch
+):
+    """gpt-5.4-mini's Responses API + reasoning + return_json sometimes
+    returns an empty output_text, which makes `json.loads('')` raise.
+    The endpoint must NOT 500 — it should fall back to a first-pending-
+    item suggestion so the user keeps getting hints.
+    """
+    import json as _json
+
+    _, headers = auth_user
+    user_id = _get_auth_user_id(headers)
+    _seed_vocab_situation(db)
+    conv = _make_voice_conv(
+        db, user_id, "bank_hint",
+        target_word_ids=["word_cuenta", "word_depositar"],
+    )
+    db.commit()
+
+    from app.services import sentence_hint_service as svc
+
+    async def boom(context, db):
+        raise _json.JSONDecodeError("Expecting value", "", 0)
+
+    async def fake_synthesize(db, *, text, voice, instructions, request_id, user_id):
+        return None, None
+
+    monkeypatch.setattr(svc, "generate_conversation", boom)
+    monkeypatch.setattr(svc, "synthesize_hint_audio", fake_synthesize)
+
+    resp = client.post(
+        f"/v1/conversations/{conv.id}/sentence-hint",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Fallback uses the first pending item — it must surface a non-empty
+    # spanish + english_gloss (no 500, no blank bubble).
+    assert body["spanish"], "expected fallback spanish text, got empty"
+    assert body["english_gloss"], "expected fallback gloss, got empty"
+    assert body["used_item_ids"]  # at least one fallback id
+
+    db.refresh(conv)
+    # The cap counter still increments — a malformed model reply still
+    # consumed the user's quota; we don't want to charge the user but
+    # we also don't want to game the cap by returning empty hints.
+    assert conv.sentence_hints_used == 1
+
+
 def test_sentence_hint_does_not_change_turn_count(
     client, db, auth_user, monkeypatch
 ):


### PR DESCRIPTION
## Why
QA log surfaced a 500 from `/sentence-hint`:

```
File "/app/app/services/llm_gateway.py", line 152, in generate_conversation
    content = json.loads(content)
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

`gpt-5.4-mini`'s Responses API + `reasoning: low` + `return_json` occasionally hands back an empty `output_text` — the model spent its budget on reasoning tokens and produced no visible JSON. The gateway raises `JSONDecodeError` *before* my service can inspect the result, which the global exception handler then turns into a 500. The user sees the generic `"Couldn't load a hint — try again."` toast and loses the click against their cap.

## Fix
Wrap the `generate_conversation` call inside `generate_sentence_hint` in `try/except (json.JSONDecodeError, Exception)`. When the gateway misfires, `content` stays `None` and the existing `_parse_hint_payload` fallback kicks in — it surfaces the first pending item (`spanish` + `english_gloss` from the candidate list) so the user gets a usable hint instead of a 500.

## Trade-off recorded in the test
The cap counter (`sentence_hints_used`) **still increments** on a fallback. The OpenAI call did fire (and cost), and we don't want to create a quota loophole where empty-response retries never count. The new test asserts this explicitly.

## Tests
- New `test_sentence_hint_falls_back_when_llm_returns_unparseable_json` — monkeypatches `generate_conversation` to raise `JSONDecodeError`, asserts the endpoint returns 200 with non-empty Spanish + gloss, and that `sentence_hints_used` advances by 1.
- Existing 8 tests still pass — the wrapping is a no-op on the success path.
- 9/9 pass locally against the test Postgres.

## Out of scope (follow-up)
A deeper fix would live in `app/services/llm_gateway.py:152` itself: don't raise on empty `output_text` when `return_json=True`, since every caller using `return_json` is exposed to the same crash. Worth a separate PR — this one keeps the blast radius contained to the hint endpoint while shipping a user-visible improvement now.

This PR is independent of #14 (prompt-quality v2) — they touch the same file but different sections; either can merge first.