### PR TITLE
Sentence hint: add prompt_prefix to response for FE framing

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -292,12 +292,16 @@ class VoiceTurnResponse(BaseModel):
 # and uses `audio_url` for the Listen affordance. `used_item_ids` is
 # what the LLM claims it used — vocab `word_*` ids and/or grammar
 # `conj_<verb>_<pronoun>` chip ids — surfaced for telemetry only.
+# `prompt_prefix` is the framing label the FE renders before `spanish`
+# (e.g., "Try saying: «...»") so the bubble reads as a suggestion to
+# the learner, not as a turn from the avatar.
 class SentenceHintResponse(BaseModel):
     spanish: str
     english_gloss: str
     audio_url: Optional[str] = None
     used_item_ids: List[str]
     hints_remaining: int
+    prompt_prefix: str = "Try saying"
 
 
 # Realtime (WebRTC) session schemas


### PR DESCRIPTION
## Summary
- Adds `prompt_prefix: str = "Try saying"` to `SentenceHintResponse` so the FE can render the avatar's speech bubble as an explicit suggestion ("Try saying: «...»") rather than a turn from the character.
- The hint sentence today renders with no distinguishing label, so visually it can be confused with avatar dialog (especially when the suggestion happens to be in first person from the learner's perspective).
- Default-only — no endpoint changes. When the FE adds locale support we can populate this from user locale without breaking the contract.

## Test plan
- [ ] FE renders the new `prompt_prefix` before `spanish` in the hint bubble
- [ ] Existing `tests/test_sentence_hint.py` still passes (no asserts on the new field; the field has a default so backward-compatible)
- [ ] Manual: trigger "Need help?" on /voice-chat, confirm the response payload includes `"prompt_prefix": "Try saying"`