### PR TITLE
Logger: serialize UUID/datetime via json.dumps default=str

### DIFF
--- a/app/core/logger.py
+++ b/app/core/logger.py
@@ -42,8 +42,14 @@ def log_event(
     # Merge extra fields
     log_entry.update(extra)
     
-    # Always print JSON to stdout (Railway/Better Stack will capture)
-    print(json.dumps(log_entry), file=sys.stdout, flush=True)
+    # Always print JSON to stdout (Railway/Better Stack will capture).
+    # `default=str` so UUIDs/datetimes/etc. coming through `user_id` or `extra`
+    # don't crash the global exception handlers — endpoints set
+    # `request.state.user_id = current_user.id` (a UUID) and we read that back
+    # here when an HTTPException bubbles up. Without `default=str` the dumps
+    # raises TypeError, which then re-enters the exception path and masks the
+    # original 4xx/5xx with an opaque 500.
+    print(json.dumps(log_entry, default=str), file=sys.stdout, flush=True)
     
     # Additionally ship to Better Stack asynchronously (fire-and-forget)
     schedule_ship_log(log_entry)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,83 @@
+"""Regression tests for app.core.logger.
+
+The structured logger sits in the global exception handler path, so a
+serialization crash here masks every 4xx/5xx the API ever returns and
+surfaces an opaque 500 instead. The tests below pin the contract that
+common non-JSON-native types (UUID, datetime) survive a `log_event`
+call without raising.
+"""
+import json
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from app.core.logger import log_event
+
+
+def _captured_stdout(monkeypatch_target_print):
+    """Wrap `print` so we can assert what `log_event` emits."""
+    captured = []
+
+    def fake_print(payload, **_kwargs):
+        captured.append(payload)
+
+    return captured, fake_print
+
+
+def test_log_event_serializes_uuid_user_id():
+    """`request.state.user_id` is sometimes set to `current_user.id` (a UUID).
+    The handler must not crash when that bubbles into `log_event`."""
+    user_id = uuid.uuid4()
+    captured = []
+
+    with patch("app.core.logger.print", lambda payload, **_: captured.append(payload)):
+        log_event(
+            level="info",
+            event="unit_test",
+            message="m",
+            request_id="req-1",
+            user_id=user_id,  # type: ignore[arg-type]  — intentional: simulate UUID leak
+        )
+
+    assert captured, "log_event should have emitted exactly one line"
+    parsed = json.loads(captured[0])
+    assert parsed["user_id"] == str(user_id)
+
+
+def test_log_event_serializes_uuid_in_extra():
+    """UUIDs that ride along in `extra` (e.g. conversation_id) must also not
+    crash dumps — the global handler injects `query_params` and similar."""
+    conv_id = uuid.uuid4()
+    captured = []
+
+    with patch("app.core.logger.print", lambda payload, **_: captured.append(payload)):
+        log_event(
+            level="warning",
+            event="unit_test",
+            message="m",
+            request_id="req-2",
+            extra={"conversation_id": conv_id, "nested": {"id": conv_id}},
+        )
+
+    parsed = json.loads(captured[0])
+    assert parsed["conversation_id"] == str(conv_id)
+    assert parsed["nested"] == {"id": str(conv_id)}
+
+
+def test_log_event_serializes_datetime_in_extra():
+    """Same defense for datetime — Pydantic models hand these out routinely."""
+    ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    captured = []
+
+    with patch("app.core.logger.print", lambda payload, **_: captured.append(payload)):
+        log_event(
+            level="info",
+            event="unit_test",
+            message="m",
+            request_id="req-3",
+            extra={"created_at": ts},
+        )
+
+    parsed = json.loads(captured[0])
+    # `default=str` calls str() on datetime, which yields ISO-ish output.
+    assert "2026-01-02" in parsed["created_at"]


### PR DESCRIPTION
## Summary
- One-line fix in \`app/core/logger.py\`: \`json.dumps(log_entry, default=str)\` instead of \`json.dumps(log_entry)\`.
- Regression tests in \`tests/test_logger.py\` covering UUID-as-\`user_id\`, UUID nested inside \`extra\`, and \`datetime\` in \`extra\`.

## The bug
\`log_event\` is invoked from the global FastAPI exception handlers in \`app/main.py\`:

\`\`\`python
@app.exception_handler(StarletteHTTPException)
async def http_exception_handler(request, exc):
    user_id = get_user_id_from_request(request)  # may be a UUID
    log_event(..., user_id=user_id, extra={...})
\`\`\`

Several endpoints set \`request.state.user_id = current_user.id\` (raw UUID, not str). When such an endpoint raises HTTPException, the handler reads the UUID back, hands it to \`log_event\`, which calls plain \`json.dumps\` and dies with:

\`\`\`
TypeError: Object of type UUID is not JSON serializable
\`\`\`

That crash re-enters the exception path and FastAPI returns an opaque 500 with a TypeError trace — every 404 / 403 / 429 / 502 from those endpoints turns into a 500 in the FE and in the test suite. The realtime + realtime-turn test suites in \`voice-chat-sentence-hint-prompt-prefix\` are currently red because of this — see \`test_create_session_conversation_not_found\`, \`test_create_session_rejects_foreign_conversation\`, \`test_create_session_rate_limited_on_second_call\`, \`test_create_session_openai_5xx_returns_502\`, \`test_create_session_openai_unreachable_returns_502\`, \`test_create_session_openai_returns_incomplete_body_is_502\`, \`test_realtime_turn_rejects_foreign_conversation\`, \`test_realtime_turn_conversation_not_found\`, \`test_realtime_turn_rejects_text_mode_conversation\`.

## Why the fix lives in the logger
There are 5+ endpoints today that do \`request.state.user_id = current_user.id\` without \`str()\`. Stringifying at every callsite is a treadmill: any new endpoint that copies the pattern reintroduces the same crash, and the failure mode (a TypeError swallowing the real status code) is genuinely hard to spot in logs. \`default=str\` at the dump boundary makes the logger robust to anything the dict contains — UUIDs, datetimes, Decimals, Pydantic models, etc. — so the fix is permanent and unconditional.

## Origin
- Original \`json.dumps(log_entry)\` introduced in commit 6fcde2a (Eric, 2026-02-19, "Implement structured logging, correlation IDs, and LLM replay system") — same commit also added the first \`request.state.user_id = current_user.id\` assignment in \`app/api/v1/conversations.py\`.
- Pattern propagated through subsequent commits (e1e986a Eric 2026-03-29, f40937e Ramón 2026-04-22, 542ca79 Ramón 2026-04-22). Commit fd976aa (Ramón 2026-04-29) is the only callsite that pre-stringifies; the comment there explicitly notes the dumps issue but the fix was scoped to one endpoint instead of the logger.

## Test plan
- [ ] Run \`pytest tests/test_logger.py\` — three new tests should pass.
- [ ] On the \`voice-chat-sentence-hint-prompt-prefix\` branch (or wherever the realtime suite lives), cherry-pick this commit and re-run the failing tests; the 8 \`test_realtime*\` UUID-serialization failures should clear.
- [ ] Smoke a 404 from \`/v1/realtime/sessions\` against a non-existent conversation_id and confirm the response is the original 404, not a 500.