### PR TITLE
Sentence hint perf: gpt-4.1-mini + offload sync OpenAI/boto3 to threads

### DIFF
--- a/app/services/llm_gateway.py
+++ b/app/services/llm_gateway.py
@@ -1,6 +1,7 @@
 """LLM Gateway for chat completions with logging and replay"""
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass
+import asyncio
 import json
 import time
 import uuid
@@ -147,7 +148,13 @@ async def generate_conversation(
         if context.max_tokens is not None:
             api_params["max_output_tokens"] = context.max_tokens
 
-        response = client.responses.create(**api_params)
+        # `client.responses.create` is the sync OpenAI SDK call; it does a
+        # blocking HTTP request to the Responses API. Inside an async
+        # handler that pins the event loop for 1–4s and starves every
+        # other concurrent request on the worker (voice-turn, hints,
+        # everything). Offload to a thread so other requests can
+        # interleave; the SDK is thread-safe.
+        response = await asyncio.to_thread(client.responses.create, **api_params)
 
         # Extract response — output_text excludes reasoning tokens
         import re

--- a/app/services/openai_media_gateway.py
+++ b/app/services/openai_media_gateway.py
@@ -1,5 +1,6 @@
 """OpenAI Media Gateway for STT and TTS with logging"""
 from typing import Optional, Dict, Any
+import asyncio
 import hashlib
 import time
 import uuid
@@ -126,8 +127,13 @@ async def transcribe_audio(
         if prompt:
             params["prompt"] = prompt
 
+        # Sync OpenAI SDK call inside an async handler — offload to a
+        # thread so the ~1s STT round-trip doesn't block other requests
+        # on the worker.
         try:
-            transcript_response = client.audio.transcriptions.create(**params)
+            transcript_response = await asyncio.to_thread(
+                client.audio.transcriptions.create, **params
+            )
         except Exception as primary_err:
             # Fallback to whisper-1 if gpt-4o-mini-transcribe rejects the audio format
             log_event(
@@ -144,7 +150,9 @@ async def transcribe_audio(
                 retry_params["language"] = language
             if prompt:
                 retry_params["prompt"] = prompt
-            transcript_response = client.audio.transcriptions.create(**retry_params)
+            transcript_response = await asyncio.to_thread(
+                client.audio.transcriptions.create, **retry_params
+            )
 
         transcript_text = transcript_response.text
         
@@ -317,14 +325,20 @@ async def synthesize_speech(
         tts_kwargs = dict(model=TTS_MODEL, voice=voice, input=text)
         if instructions:
             tts_kwargs["instructions"] = instructions
-        response = client.audio.speech.create(**tts_kwargs)
-        
-        # Save to file and get size
-        audio_bytes_written = 0
-        with open(output_path, "wb") as f:
-            for chunk in response.iter_bytes():
-                f.write(chunk)
-                audio_bytes_written += len(chunk)
+        # The OpenAI SDK is synchronous; calling it directly in an async
+        # handler blocks the event loop for the full TTS round-trip
+        # (~1–2s) and starves every other request on the worker. Offload
+        # the network call AND the chunked file write to a thread.
+        def _tts_and_write() -> int:
+            resp = client.audio.speech.create(**tts_kwargs)
+            written = 0
+            with open(output_path, "wb") as f:
+                for chunk in resp.iter_bytes():
+                    f.write(chunk)
+                    written += len(chunk)
+            return written
+
+        audio_bytes_written = await asyncio.to_thread(_tts_and_write)
         
         # Calculate latency
         latency_ms = int((time.time() - start_time) * 1000)

--- a/app/services/sentence_hint_service.py
+++ b/app/services/sentence_hint_service.py
@@ -22,6 +22,7 @@ items for an already-mastered verb.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from dataclasses import dataclass
@@ -329,16 +330,21 @@ async def generate_sentence_hint(
         prompt_version="v2",
         messages=messages,
         return_json=True,
-        # Bumped from 200 → 300 to give the model headroom for natural
-        # 12–14 word sentences plus the gloss without truncating mid-JSON.
-        max_tokens=300,
+        # Non-reasoning model — a single first-person sentence with a
+        # gloss is well within gpt-4.1-mini's range, and we save the
+        # 1.5–3s of reasoning tokens that gpt-5.4-mini was burning on
+        # every hint. Few-shots in the system prompt do the steering.
+        model="gpt-4.1-mini",
+        # 150 fits the JSON payload (sentence + gloss + ids) with
+        # margin; 300 was a holdover from the reasoning-model era when
+        # truncation mid-JSON was a real risk.
+        max_tokens=150,
     )
 
-    # gpt-5.4-mini's Responses API + reasoning: low + return_json
-    # occasionally hands back an empty `output_text` (the LLM gateway
-    # then chokes on `json.loads("")`). Treat any failure here as
-    # "model didn't produce parseable output" and let the parser fall
-    # back to a first-pending-item suggestion — better than 500'ing the
+    # Some Responses API edge cases (empty output_text, malformed
+    # JSON) used to surface here under the reasoning model. The
+    # try/except stays as defense-in-depth so a misfire still falls
+    # back to a first-pending-item suggestion instead of 500'ing the
     # user out of the encounter.
     content: Any = None
     llm_request_id: Optional[str] = None
@@ -433,7 +439,10 @@ async def synthesize_hint_audio(
         logger.error(f"[SentenceHint] TTS failed: {e}")
         return None, None
 
-    audio_url = upload_to_r2(output_path, filename)
+    # boto3 is synchronous — running it directly here would block the
+    # event loop for the upload's ~200–500ms. Push it to a thread so the
+    # hint endpoint stops being a bottleneck for concurrent requests.
+    audio_url = await asyncio.to_thread(upload_to_r2, output_path, filename)
     tts_request_id = _latest_tts_request_id(db, request_id)
     return audio_url, tts_request_id
 


### PR DESCRIPTION
## Summary

Hint generation was perceived as 5–9 s of latency. Root causes:

1. **`gpt-5.4-mini` con `reasoning: low`** para una sola oración — quemaba 1.5–3 s de reasoning tokens antes de emitir el JSON.
2. **OpenAI SDK síncrono dentro de handlers async** — `client.responses.create` / `client.audio.speech.create` / `client.audio.transcriptions.create` bloqueaban el event loop durante todo el round-trip HTTP (~1–4 s), serializando voice-turn + hints en cada worker.
3. **`upload_to_r2` (boto3) síncrono** después del TTS — 200–500 ms más bloqueando el loop.
4. `max_tokens=300` heredado de la era reasoning; el payload real cabe en ~120.

## Cambios

- `app/services/sentence_hint_service.py`
  - `model="gpt-4.1-mini"` para el hint (no-reasoning).
  - `max_tokens=300 → 150`.
  - `upload_to_r2` envuelto en `asyncio.to_thread`.
- `app/services/llm_gateway.py`
  - `client.responses.create` envuelto en `asyncio.to_thread`. Beneficia a **todos** los callers (no solo hints).
- `app/services/openai_media_gateway.py`
  - `client.audio.transcriptions.create` (primario + fallback whisper-1) envuelto en `asyncio.to_thread`.
  - `client.audio.speech.create` + chunked file write envuelto en una sola función `_tts_and_write` ejecutada en thread.

Sin cambios de API/contrato — el FE no necesita ajustes.

## Impacto esperado

| Métrica | Antes | Después (esperado) |
|---|---|---|
| Hint p50 | ~5–6 s | ~1.5–2 s |
| Hint p95 | ~8–9 s | ~3 s |
| Concurrencia por worker | 1 request bloqueante a la vez | múltiples requests interleavadas |

El segundo punto importa especialmente porque el hint y el voice-turn corren en paralelo durante la misma sesión: hoy el hint pausa el voice-turn (y viceversa). Con `to_thread` se interleavan.

## Test plan

- [ ] CI: pytest en Railway QA con Postgres real (no se puede correr localmente sin DB).
- [ ] Smoke local: módulos importan, funciones puras (`_parse_hint_payload`, `build_hint_messages`) verificadas vía script.
- [ ] Validar en QA: tocar el botón "Need help?" en voice-chat varias veces y medir latencia perceived. Comparar contra producción.
- [ ] Verificar que `/v1/situations/admin/ai-logs` muestra los nuevos hint LLMs como `gpt-4.1-mini` y que `latency_ms` baja.
- [ ] Verificar que la calidad del hint sigue siendo buena (sentencias naturales, no "vocab-quiz") con los few-shots actuales — la calidad fue un objetivo principal del prompt v2.

## Follow-ups (no en este PR)

- **Two-phase response**: devolver el texto del hint apenas termina el LLM y el audio en una segunda llamada (o vía SSE/streaming). Requiere ajuste FE; reduciría el "tiempo a primer pixel" del bocadillo a ~1 s.
- **Pre-generar el hint en background** apenas el voice-turn arranca: cuando el user toca la bombilla ya está listo.
- **Reducir DB commits** del gateway (hoy hay 2 por LLM y 2 por TTS para el log de auditoría).