### PR TITLE
Avatar dynamics: level-aware prompts, chip-anchored completion, anti-…

### DIFF
--- a/app/api/v1/conversations.py
+++ b/app/api/v1/conversations.py
@@ -26,13 +26,16 @@ from app.services.openai_media_gateway import transcribe_audio as gateway_transc
 from fastapi import Request
 from app.services.word_detection import detect_words_in_text, get_words_by_ids
 from app.services.conversation_service import (
+    check_chat_chip_completion,
     check_conversation_complete,
     update_user_word_stats,
     get_missing_word_ids
 )
 from app.services.encounter_messages import get_initial_message_for_encounter
 from app.api.v1.situations import get_vocab_level, get_grammar_level
+from app.services.learner_context import ChipTarget, LearnerContext
 from app.services.voice_turn_service import (
+    EXCHANGE_HARD_LIMIT,
     build_transcription_prompt,
     build_conversation_prompt,
     build_grammar_system_prompt,
@@ -43,383 +46,89 @@ from app.services.voice_turn_service import (
     check_completion,
     persist_turn,
 )
-from app.data.grammar_situations import get_grammar_config
+from app.data.grammar_situations import get_chat_target_forms, get_grammar_config
 from app.services.alt_language_service import apply_alt_language, get_target_language_name
 from app.utils.audio import generate_audio_filename, get_audio_path, get_audio_url, upload_to_r2
 router = APIRouter()
 
 
-def _build_grammar_hint(pronoun: str, verb: str, verb_english: str) -> str:
-    """Build a natural English hint question for a specific pronoun+verb target.
+def _enriched_chat_target_forms(situation_id: str) -> list[dict]:
+    """Return `get_chat_target_forms` items with a stable BE chip id.
 
-    Uses verb-specific overrides for irregular/awkward English, and a template
-    fallback for regular verbs where 'Does your sister [verb]?' sounds natural.
+    The backend stores these on `Conversation.chat_target_forms_json`
+    so completion can be checked server-side. The id convention matches
+    what the FE synthesizes in `ImmersiveVoiceScene.applyDetectedWords`
+    (`form:{spanish}:{pronoun}`) so chip ticks stay consistent across
+    the API boundary.
     """
-    # ── Verb-specific overrides (irregular English or verbs needing context) ──
-    _VERB_QUESTIONS = {
-        "ser": {
-            "yo": "Are you from here?",
-            "tú": "I'm from Mexico. Where am I from?",
-            "él": "Is your brother tall?",
-            "ella": "Is your sister a student?",
-            "usted": "Is your boss strict?",
-            "nosotros": "Are you and your friends from here?",
-            "nosotras": "Are you and your sisters happy here?",
-            "ellos": "Are your friends from this city?",
-            "ellas": "Are your female friends students?",
-            "ustedes": "Are you all from the same place?",
-        },
-        "estar": {
-            "yo": "How are you feeling right now?",
-            "tú": "I feel great today. How am I doing?",
-            "él": "Is your brother feeling okay?",
-            "ella": "Is your sister at home right now?",
-            "usted": "Is your boss in the office today?",
-            "nosotros": "Are you and your friends happy here?",
-            "nosotras": "Are you and your sisters feeling well?",
-            "ellos": "Are your friends at the party?",
-            "ellas": "Are your female friends here today?",
-            "ustedes": "Are you all ready to go?",
-        },
-        "ir": {
-            "yo": "Where do you go on weekends?",
-            "tú": "I go to the park every day. Where do I go?",
-            "él": "Does your brother go to school?",
-            "ella": "Does your sister go to work?",
-            "usted": "Does your boss go on vacation?",
-            "nosotros": "Do you and your friends go out together?",
-            "nosotras": "Do you and your sisters go shopping?",
-            "ellos": "Do your friends go to the beach?",
-            "ellas": "Do your female friends go dancing?",
-            "ustedes": "Do you all go to the same restaurant?",
-        },
-        "tener": {
-            "yo": "Do you have any pets?",
-            "tú": "I have a big family. What do I have?",
-            "él": "Does your brother have a car?",
-            "ella": "Does your sister have children?",
-            "usted": "Does your boss have a lot of meetings?",
-            "nosotros": "Do you and your friends have plans tonight?",
-            "nosotras": "Do you and your sisters have similar taste?",
-            "ellos": "Do your friends have jobs?",
-            "ellas": "Do your female friends have kids?",
-            "ustedes": "Do you all have the same schedule?",
-        },
-        "dar": {
-            "yo": "Do you give gifts on birthdays?",
-            "tú": "I give advice to my friends. What do I give?",
-            "él": "Does your brother give you help?",
-            "ella": "Does your sister give good advice?",
-            "usted": "Does your boss give feedback?",
-            "nosotros": "Do you and your friends give presents?",
-            "nosotras": "Do you and your sisters give each other gifts?",
-            "ellos": "Do your friends give you rides?",
-            "ellas": "Do your female friends give parties?",
-            "ustedes": "Do you all give tips at restaurants?",
-        },
-        "venir": {
-            "yo": "Do you come here often?",
-            "tú": "I come here every week. How often do I come?",
-            "él": "Does your brother come to visit?",
-            "ella": "Does your sister come to this area?",
-            "usted": "Does your boss come to the office early?",
-            "nosotros": "Do you and your friends come here together?",
-            "nosotras": "Do you and your sisters come to this park?",
-            "ellos": "Do your friends come to your house?",
-            "ellas": "Do your female friends come to the party?",
-            "ustedes": "Do you all come from the same town?",
-        },
-        "hacer": {
-            "yo": "What do you do on weekends?",
-            "tú": "I make breakfast every day. What do I make?",
-            "él": "What does your brother do for work?",
-            "ella": "What does your sister do after school?",
-            "usted": "What does your boss do at meetings?",
-            "nosotros": "What do you and your friends do for fun?",
-            "nosotras": "What do you and your sisters do together?",
-            "ellos": "What do your friends do on Friday nights?",
-            "ellas": "What do your female friends do on weekends?",
-            "ustedes": "What do you all do after class?",
-        },
-        "poder": {
-            "yo": "Can you swim?",
-            "tú": "I can cook really well. What can I do?",
-            "él": "Can your brother drive?",
-            "ella": "Can your sister play guitar?",
-            "usted": "Can your boss speak English?",
-            "nosotros": "Can you and your friends come tomorrow?",
-            "nosotras": "Can you and your sisters help?",
-            "ellos": "Can your friends play soccer?",
-            "ellas": "Can your female friends join us?",
-            "ustedes": "Can you all come to dinner?",
-        },
-        "querer": {
-            "yo": "What do you want for dinner?",
-            "tú": "I want pizza tonight. What do I want?",
-            "él": "Does your brother want to come?",
-            "ella": "Does your sister want coffee?",
-            "usted": "Does your boss want the report today?",
-            "nosotros": "Do you and your friends want to go out?",
-            "nosotras": "Do you and your sisters want dessert?",
-            "ellos": "Do your friends want to play?",
-            "ellas": "Do your female friends want to join?",
-            "ustedes": "Do you all want to go to the beach?",
-        },
-        "decir": {
-            "yo": "What do you say when you greet someone?",
-            "tú": "I always say 'good morning'. What do I say?",
-            "él": "What does your brother say about it?",
-            "ella": "What does your sister say?",
-            "usted": "What does your boss say about the project?",
-            "nosotros": "What do you and your friends say?",
-            "nosotras": "What do you and your sisters say about it?",
-            "ellos": "What do your friends say?",
-            "ellas": "What do your female friends say?",
-            "ustedes": "What do you all say when that happens?",
-        },
-        "salir": {
-            "yo": "Do you go out on weekends?",
-            "tú": "I go out every Friday. When do I go out?",
-            "él": "Does your brother go out at night?",
-            "ella": "Does your sister go out with friends?",
-            "usted": "Does your boss leave the office early?",
-            "nosotros": "Do you and your friends go out together?",
-            "nosotras": "Do you and your sisters go out dancing?",
-            "ellos": "Do your friends go out on Saturday?",
-            "ellas": "Do your female friends go out often?",
-            "ustedes": "Do you all go out together?",
-        },
-        "conocer": {
-            "yo": "Do you know this neighborhood well?",
-            "tú": "I know a great restaurant. Do you know what I know?",
-            "él": "Does your brother know the area?",
-            "ella": "Does your sister know my friend?",
-            "usted": "Does your boss know about this?",
-            "nosotros": "Do you and your friends know the city?",
-            "nosotras": "Do you and your sisters know the neighbors?",
-            "ellos": "Do your friends know the beach?",
-            "ellas": "Do your female friends know the park?",
-            "ustedes": "Do you all know each other well?",
-        },
-        "pedir": {
-            "yo": "What do you order at restaurants?",
-            "tú": "I always order coffee. What do I order?",
-            "él": "What does your brother order?",
-            "ella": "What does your sister order for lunch?",
-            "usted": "What does your boss request?",
-            "nosotros": "What do you and your friends order?",
-            "nosotras": "What do you and your sisters order?",
-            "ellos": "What do your friends order at the cafe?",
-            "ellas": "What do your female friends ask for?",
-            "ustedes": "What do you all order when you go out?",
-        },
-        "seguir": {
-            "yo": "Do you follow any sports teams?",
-            "tú": "I follow soccer. What do I follow?",
-            "él": "Does your brother follow the news?",
-            "ella": "Does your sister follow fashion?",
-            "usted": "Does your boss keep going with the plan?",
-            "nosotros": "Do you and your friends keep studying?",
-            "nosotras": "Do you and your sisters keep practicing?",
-            "ellos": "Do your friends keep playing?",
-            "ellas": "Do your female friends keep exercising?",
-            "ustedes": "Do you all keep going to class?",
-        },
-        "conseguir": {
-            "yo": "Do you get good grades?",
-            "tú": "I always get a good seat. What do I get?",
-            "él": "Does your brother get tickets easily?",
-            "ella": "Does your sister get good deals?",
-            "usted": "Does your boss get results?",
-            "nosotros": "Do you and your friends get together often?",
-            "nosotras": "Do you and your sisters get what you need?",
-            "ellos": "Do your friends get good jobs?",
-            "ellas": "Do your female friends get discounts?",
-            "ustedes": "Do you all manage to get there on time?",
-        },
-        "morir": {
-            "yo": "Are you dying of hunger right now?",
-            "tú": "I'm dying of thirst. What am I dying of?",
-            "él": "Is your brother dying to see the movie?",
-            "ella": "Is your sister dying to go on vacation?",
-            "usted": "Is your boss dying to finish the project?",
-            "nosotros": "Are you and your friends dying of laughter?",
-            "nosotras": "Are you and your sisters dying to try it?",
-            "ellos": "Are your friends dying to go to the concert?",
-            "ellas": "Are your female friends dying to see it?",
-            "ustedes": "Are you all dying of boredom?",
-        },
-        "abrir": {
-            "yo": "Do you open the windows in the morning?",
-            "tú": "I open my shop at nine. When do I open it?",
-            "él": "Does your brother open the door for people?",
-            "ella": "Does your sister open her gifts right away?",
-            "usted": "Does your boss open the meeting?",
-            "nosotros": "Do you and your friends open a bottle of wine?",
-            "nosotras": "Do you and your sisters open presents together?",
-            "ellos": "Do your friends open their books in class?",
-            "ellas": "Do your female friends open the store early?",
-            "ustedes": "Do you all open your laptops in class?",
-        },
-        "cerrar": {
-            "yo": "Do you close the windows at night?",
-            "tú": "I close the store at nine. When do I close it?",
-            "él": "Does your brother close the door?",
-            "ella": "Does your sister close her eyes to sleep?",
-            "usted": "Does your boss close the office early?",
-            "nosotros": "Do you and your friends close the restaurant?",
-            "nosotras": "Do you and your sisters close up the house?",
-            "ellos": "Do your friends close the gate?",
-            "ellas": "Do your female friends close the shop?",
-            "ustedes": "Do you all close everything before leaving?",
-        },
-        "caer": {
-            "yo": "Do you fall asleep easily?",
-            "tú": "I fall asleep late. When do I fall asleep?",
-            "él": "Does your brother fall often when playing?",
-            "ella": "Does your sister drop things a lot?",
-            "usted": "Does your boss drop by unexpectedly?",
-            "nosotros": "Do you and your friends fall behind in class?",
-            "nosotras": "Do you and your sisters fall asleep watching movies?",
-            "ellos": "Do your friends trip and fall sometimes?",
-            "ellas": "Do your female friends drop their phones?",
-            "ustedes": "Do you all fall asleep during long movies?",
-        },
-        "valer": {
-            "yo": "How much is your phone worth?",
-            "tú": "My watch is worth a lot. How much is it worth?",
-            "él": "Is your brother's car worth a lot?",
-            "ella": "Is your sister's painting worth something?",
-            "usted": "Is your boss's advice worth following?",
-            "nosotros": "Is your group's effort worth it?",
-            "nosotras": "Is your sisters' collection worth something?",
-            "ellos": "Are your friends' tickets worth the price?",
-            "ellas": "Are your female friends' crafts worth selling?",
-            "ustedes": "Is your team's work worth the time?",
-        },
-        "oír": {
-            "yo": "Do you hear the music?",
-            "tú": "I hear birds every morning. What do I hear?",
-            "él": "Does your brother hear the neighbors?",
-            "ella": "Does your sister hear the alarm?",
-            "usted": "Does your boss hear the complaints?",
-            "nosotros": "Do you and your friends hear the noise?",
-            "nosotras": "Do you and your sisters hear the dog barking?",
-            "ellos": "Do your friends hear the thunder?",
-            "ellas": "Do your female friends hear the music?",
-            "ustedes": "Do you all hear that sound?",
-        },
-        "poner": {
-            "yo": "Where do you put your keys?",
-            "tú": "I put my bag on the table. Where do I put it?",
-            "él": "Does your brother put sugar in his coffee?",
-            "ella": "Does your sister put music on?",
-            "usted": "Does your boss put pressure on you?",
-            "nosotros": "Do you and your friends set the table?",
-            "nosotras": "Do you and your sisters put decorations up?",
-            "ellos": "Do your friends put effort into studying?",
-            "ellas": "Do your female friends put on makeup?",
-            "ustedes": "Do you all set up the chairs?",
-        },
-        "traer": {
-            "yo": "Do you bring lunch to work?",
-            "tú": "I bring dessert to parties. What do I bring?",
-            "él": "Does your brother bring his guitar?",
-            "ella": "Does your sister bring food to share?",
-            "usted": "Does your boss bring coffee to meetings?",
-            "nosotros": "Do you and your friends bring snacks?",
-            "nosotras": "Do you and your sisters bring presents?",
-            "ellos": "Do your friends bring drinks?",
-            "ellas": "Do your female friends bring their kids?",
-            "ustedes": "Do you all bring something to the party?",
-        },
-        "producir": {
-            "yo": "Do you produce any content online?",
-            "tú": "I produce videos. What do I produce?",
-            "él": "Does your brother produce music?",
-            "ella": "Does your sister produce art?",
-            "usted": "Does your boss produce reports?",
-            "nosotros": "Do you and your friends produce a podcast?",
-            "nosotras": "Do you and your sisters make crafts?",
-            "ellos": "Do your friends produce content?",
-            "ellas": "Do your female friends make things to sell?",
-            "ustedes": "Do you all produce something together?",
-        },
-        "construir": {
-            "yo": "Do you build things at home?",
-            "tú": "I build furniture. What do I build?",
-            "él": "Does your brother build model planes?",
-            "ella": "Does your sister build websites?",
-            "usted": "Does your boss build the team?",
-            "nosotros": "Do you and your friends build projects?",
-            "nosotras": "Do you and your sisters build things together?",
-            "ellos": "Do your friends build houses?",
-            "ellas": "Do your female friends build community?",
-            "ustedes": "Do you all build something together?",
-        },
-        "recoger": {
-            "yo": "Do you pick up your kids from school?",
-            "tú": "I pick up the mail. What do I pick up?",
-            "él": "Does your brother pick up after himself?",
-            "ella": "Does your sister pick up her room?",
-            "usted": "Does your boss pick up the phone?",
-            "nosotros": "Do you and your friends clean up after?",
-            "nosotras": "Do you and your sisters tidy up together?",
-            "ellos": "Do your friends pick up trash at the park?",
-            "ellas": "Do your female friends pick up supplies?",
-            "ustedes": "Do you all pick up after the party?",
-        },
-        "dirigir": {
-            "yo": "Do you manage a team at work?",
-            "tú": "I direct the school play. What do I direct?",
-            "él": "Does your brother run a business?",
-            "ella": "Does your sister manage the project?",
-            "usted": "Does your boss lead the department?",
-            "nosotros": "Do you and your friends run the club?",
-            "nosotras": "Do you and your sisters lead the group?",
-            "ellos": "Do your friends manage the event?",
-            "ellas": "Do your female friends run the organization?",
-            "ustedes": "Do you all manage it together?",
-        },
-        "convencer": {
-            "yo": "Do you convince people easily?",
-            "tú": "I convince my friends to try new food. What do I do?",
-            "él": "Does your brother convince you to go out?",
-            "ella": "Does your sister convince you to exercise?",
-            "usted": "Does your boss convince clients easily?",
-            "nosotros": "Do you and your friends persuade each other?",
-            "nosotras": "Do you and your sisters convince your parents?",
-            "ellos": "Do your friends convince you to stay up late?",
-            "ellas": "Do your female friends convince you to shop?",
-            "ustedes": "Do you all convince the teacher to cancel homework?",
-        },
-    }
+    forms = get_chat_target_forms(situation_id)
+    enriched: list[dict] = []
+    for f in forms:
+        spanish = f.get("spanish") or ""
+        pronoun = f.get("pronoun") or ""
+        enriched.append({
+            **f,
+            "id": f.get("id") or f"form:{spanish}:{pronoun}",
+        })
+    return enriched
 
-    # Check for verb-specific override
-    if verb in _VERB_QUESTIONS and pronoun in _VERB_QUESTIONS[verb]:
-        return _VERB_QUESTIONS[verb][pronoun]
 
-    # ── Template fallback for regular verbs ──
-    action = verb_english[3:] if verb_english.startswith("to ") else verb_english
-    # Clean up parentheticals and slashes
-    if "(" in action:
-        action = action[:action.index("(")].strip()
-    if "/" in action:
-        action = action.split("/")[0].strip()
+def _make_learner_context(
+    user: User,
+    situation: Situation,
+    conversation: Conversation,
+    *,
+    vocab_level: int,
+    grammar_level: float,
+    completed_chip_ids: list[str] | None = None,
+    target_word_objects: list[Word] | None = None,
+) -> LearnerContext:
+    """Assemble a LearnerContext for prompt building.
 
-    _FRAMES = {
-        "yo": f"Do you {action}?",
-        "tú": f"I {action} every day. What do I {action}?",
-        "él": f"Does your brother {action}?",
-        "ella": f"Does your sister {action}?",
-        "usted": f"Does your boss {action}?",
-        "nosotros": f"Do you and your friends {action}?",
-        "nosotras": f"Do you and your sisters {action}?",
-        "ellos": f"Do your friends {action}?",
-        "ellas": f"Do your female friends {action}?",
-        "ustedes": f"Do you all {action}?",
-    }
-    return _FRAMES.get(pronoun, f"Do you {action}?")
+    For grammar chat lessons (`*_chat`) we read chips off
+    `conversation.chat_target_forms_json` (snapshotted at creation).
+    For vocab encounters we project `target_word_ids` into chips so the
+    target-steering block has something to render either way.
+
+    `completed_chip_ids` defaults to `used_spoken_word_ids` for vocab
+    encounters and `[]` for grammar chats. Callers that already ran
+    `check_chat_chip_completion` should pass the returned list to keep
+    the prompt's "what's done" view consistent with chip-tick state.
+    """
+    chips: list[ChipTarget] = []
+    chat_forms = conversation.chat_target_forms_json or []
+
+    if chat_forms:
+        for form in chat_forms:
+            chips.append(ChipTarget(
+                id=form.get("id") or f"form:{form.get('spanish', '')}:{form.get('pronoun', '')}",
+                spanish=form.get("spanish") or "",
+                english=form.get("english") or "",
+                verb=form.get("verb"),
+                pronoun=form.get("pronoun"),
+            ))
+        if completed_chip_ids is None:
+            completed_chip_ids = []
+    else:
+        words = target_word_objects or []
+        for word in words:
+            chips.append(ChipTarget(
+                id=word.id,
+                spanish=word.spanish,
+                english=word.english,
+            ))
+        if completed_chip_ids is None:
+            completed_chip_ids = list(conversation.used_spoken_word_ids or [])
+
+    return LearnerContext(
+        spanish_level=user.q0_spanish_level,
+        vocab_level=vocab_level,
+        grammar_level=grammar_level,
+        goal=situation.goal,
+        target_chips=chips,
+        completed_chip_ids=completed_chip_ids,
+        consecutive_no_progress_turns=conversation.consecutive_no_progress_turns or 0,
+    )
 
 
 # Cache for initial message TTS audio URLs — avoids re-synthesizing the same audio
@@ -551,11 +260,19 @@ async def create_conversation(
             Conversation.status == "active"
         ).order_by(Conversation.created_at.desc()).with_for_update().first()
 
+        # Snapshot the FE's chip list onto the conversation for grammar chat
+        # lessons. `_enriched_chat_target_forms` returns [] for vocab/non-chat
+        # situations — we leave `chat_target_forms_json` NULL there so the
+        # legacy infinitive-completion path keeps running unchanged.
+        chat_forms_for_db = _enriched_chat_target_forms(situation.id)
+
         if voice_conv:
             # Reset spoken words so backend + frontend start from same empty state.
             # Without this, reused conversations carry stale used_spoken_word_ids
             # which causes completion to fire before all word chips show checkmarks.
             voice_conv.used_spoken_word_ids = []
+            voice_conv.consecutive_no_progress_turns = 0
+            voice_conv.chat_target_forms_json = chat_forms_for_db or None
             db.commit()
 
         if not voice_conv:
@@ -565,12 +282,13 @@ async def create_conversation(
                 mode="voice",
                 target_word_ids=target_word_ids,
                 used_typed_word_ids=[],
-                used_spoken_word_ids=[]
+                used_spoken_word_ids=[],
+                chat_target_forms_json=chat_forms_for_db or None,
             )
             db.add(voice_conv)
             db.commit()
             db.refresh(voice_conv)
-        
+
         vocab_level = get_vocab_level(db, current_user.id)
         grammar_level = get_grammar_level(db, current_user.id)
         language_mode = get_language_mode(situation.encounter_number, vocab_level, grammar_level)
@@ -587,14 +305,19 @@ async def create_conversation(
         from app.config import settings as _cfg
         initial_audio_url = f"{_cfg.r2_public_url}/initial_msg_{situation.id}.mp3" if _cfg.r2_public_url else None
 
+        learner_ctx = _make_learner_context(
+            current_user, situation, voice_conv,
+            vocab_level=vocab_level, grammar_level=grammar_level,
+            target_word_objects=final_words,
+        )
         system_prompt = build_system_prompt(
             situation.animation_type, situation.id, language_mode,
             alt_language=current_user.alt_language,
+            learner_ctx=learner_ctx,
         )
-        from app.data.grammar_situations import get_chat_target_forms
         from app.schemas import ChatTargetForm
         chat_target_forms = [
-            ChatTargetForm(**f) for f in get_chat_target_forms(situation.id)
+            ChatTargetForm(**f) for f in chat_forms_for_db
         ]
         scene = situation.animation_type
         if situation.animation_type == "grammar":
@@ -614,23 +337,30 @@ async def create_conversation(
     else:
         # No existing conversation - this shouldn't happen if startSituation was called first
         # But create one anyway as fallback
-        encounter_word_ids, high_freq_word_ids = select_words_for_situation(db, current_user.id, request.situation_id)
+        encounter_word_ids, high_freq_word_ids = select_words_for_situation(
+            db, current_user.id, request.situation_id,
+            vocab_level=get_vocab_level(db, current_user.id),
+            spanish_level=current_user.q0_spanish_level,
+        )
         target_word_ids = encounter_word_ids + high_freq_word_ids
         all_words = db.query(Word).filter(Word.id.in_(target_word_ids)).all()
         final_words = sort_words_encounter_first(all_words, request.situation_id, db, target_word_ids)
-        
+
+        chat_forms_for_db = _enriched_chat_target_forms(situation.id)
+
         conversation = Conversation(
             user_id=current_user.id,
             situation_id=request.situation_id,
             mode=request.mode,
             target_word_ids=target_word_ids,
             used_typed_word_ids=[],
-            used_spoken_word_ids=[]
+            used_spoken_word_ids=[],
+            chat_target_forms_json=chat_forms_for_db or None,
         )
         db.add(conversation)
         db.commit()
         db.refresh(conversation)
-        
+
         vocab_level = get_vocab_level(db, current_user.id)
         grammar_level = get_grammar_level(db, current_user.id)
         language_mode = get_language_mode(situation.encounter_number, vocab_level, grammar_level)
@@ -645,14 +375,19 @@ async def create_conversation(
         from app.config import settings as _cfg2
         initial_audio_url = f"{_cfg2.r2_public_url}/initial_msg_{situation.id}.mp3" if _cfg2.r2_public_url else None
 
+        learner_ctx = _make_learner_context(
+            current_user, situation, conversation,
+            vocab_level=vocab_level, grammar_level=grammar_level,
+            target_word_objects=final_words,
+        )
         system_prompt = build_system_prompt(
             situation.animation_type, situation.id, language_mode,
             alt_language=current_user.alt_language,
+            learner_ctx=learner_ctx,
         )
-        from app.data.grammar_situations import get_chat_target_forms
         from app.schemas import ChatTargetForm
         chat_target_forms = [
-            ChatTargetForm(**f) for f in get_chat_target_forms(situation.id)
+            ChatTargetForm(**f) for f in chat_forms_for_db
         ]
         scene = situation.animation_type
         if situation.animation_type == "grammar":
@@ -960,100 +695,59 @@ async def voice_turn_respond(
     if alt_language and language_mode in ("spanish_text", "spanish_audio"):
         language_mode = language_mode.replace("spanish_", f"{alt_language}_")
 
-    # Word guidance — steer AI toward unused target words
-    missing_ids = get_missing_word_ids(conversation, "voice")
-    word_guidance_system = ""
+    # `persist_turn` from step 1 (`POST /voice-turn`) already updated the
+    # cumulative chip set on the conversation row, so we just read it here.
+    # Refresh first so we see what step 1 wrote in this same request cycle.
+    db.refresh(conversation)
+    completed_chip_ids = list(conversation.completed_chip_ids or [])
+    chips_total = len(conversation.chat_target_forms_json or [])
+    chip_complete = chips_total > 0 and len(completed_chip_ids) >= chips_total
 
-    # For grammar situations with drill_targets, build specific verb+pronoun guidance
-    grammar_cfg = get_grammar_config(conversation.situation_id)
-    drill_targets = grammar_cfg.get("drill_targets", []) if grammar_cfg else []
-    grammar_inject_message = None  # assistant "thinking" message for grammar targeting
-    if drill_targets and grammar_cfg.get("drill_config", {}).get("answers"):
-        answers = grammar_cfg["drill_config"]["answers"]
-        # Find which conjugated forms the user has already said
-        import re as _re
-        def _extract_words(text: str) -> set:
-            return set(_re.sub(r'[.,!?¿¡]', '', text.lower()).split())
-        transcript_words = set()
-        if body.messages_json:
-            try:
-                for msg in json_module.loads(body.messages_json):
-                    if msg.get("role") == "user":
-                        transcript_words.update(_extract_words(msg["content"]))
-            except (json_module.JSONDecodeError, TypeError):
-                pass
-        transcript_words.update(_extract_words(user_transcript))
+    # The v3 prompt is level-aware, target-anchored, and reads chip state
+    # straight off the conversation. No more side-band injection of
+    # English "thinking" messages — targeting lives entirely in the
+    # system prompt now.
+    learner_ctx = _make_learner_context(
+        current_user, situation, conversation,
+        vocab_level=vocab_level, grammar_level=grammar_level,
+        completed_chip_ids=completed_chip_ids if conversation.chat_target_forms_json else None,
+        target_word_objects=words,
+    )
 
-        # Find first remaining target
-        next_target = None
-        for t in drill_targets:
-            verb, pronoun = t["verb"], t["pronoun"]
-            conjugated = answers.get(verb, {}).get(pronoun, "")
-            if conjugated and conjugated.lower() not in transcript_words:
-                next_target = {"verb": verb, "pronoun": pronoun, "conjugated": conjugated}
-                break
-
-        if next_target:
-            from app.data.grammar_situations import GRAMMAR_WORD_TRANSLATIONS
-            v, p, c = next_target["verb"], next_target["pronoun"], next_target["conjugated"]
-            eng = GRAMMAR_WORD_TRANSLATIONS.get(v, v)
-            # Build a pronoun-appropriate hint question
-            hint = _build_grammar_hint(p, v, eng)
-            grammar_inject_message = (
-                f"Next I need to get the student to say '{c}' ({p} + {v}). "
-                f"I'll ask exactly: \"{hint}\""
-            )
-    elif missing_ids:
-        missing_words = get_words_by_ids(db, missing_ids)
-        lang = get_target_language_name(alt_language)
-        missing_pairs = [f"{w.spanish} ({w.english})" for w in missing_words]
-        word_guidance_system = (
-            f"\n\nThe student still needs to say these {lang} words: {', '.join(missing_pairs)}. "
-            f"Steer the conversation toward topics where they'd naturally use them. "
-            f"Don't say the target {lang} words yourself."
-        )
-
-    # Build messages for Realtime API
-    # Always build the system prompt — frontend messages don't include it
     grammar_config_for_prompt = get_grammar_config(conversation.situation_id)
     if grammar_config_for_prompt:
-        system_prompt = build_grammar_system_prompt(conversation.situation_id, language_mode=language_mode, alt_language=alt_language)
+        system_prompt = build_grammar_system_prompt(
+            conversation.situation_id,
+            language_mode=language_mode,
+            alt_language=alt_language,
+            learner_ctx=learner_ctx,
+        )
     else:
         system_prompt = get_conversation_system_prompt(
             language_mode, alt_language=alt_language,
             animation_type=situation.animation_type if situation else "",
             situation_id=conversation.situation_id,
+            learner_ctx=learner_ctx,
         )
-
-    # Append word guidance to system prompt (non-grammar situations only)
-    if not grammar_inject_message:
-        system_prompt += word_guidance_system
 
     if frontend_messages:
         llm_messages = [{"role": "system", "content": system_prompt}]
         for msg in frontend_messages:
             if msg["role"] != "system":
                 llm_messages.append(msg)
-        if grammar_inject_message:
-            # Grammar: inject assistant "thinking" with the next target + hint
-            llm_messages.append({"role": "user", "content": user_transcript})
-            llm_messages.append({"role": "assistant", "content": grammar_inject_message})
-        else:
-            llm_messages.append({"role": "user", "content": user_transcript})
+        llm_messages.append({"role": "user", "content": user_transcript})
     else:
-        grammar_config = get_grammar_config(conversation.situation_id)
-        if grammar_config:
-            system_prompt = build_grammar_system_prompt(conversation.situation_id, language_mode=language_mode, alt_language=alt_language)
+        # Cold-start: no FE history. Pair the v3 system prompt with a
+        # minimal user-prompt that surfaces the latest transcript and the
+        # situation context. The legacy `build_grammar_user_prompt` /
+        # `build_conversation_prompt` helpers still do the heavy lifting
+        # for the non-history case so we don't duplicate that copy here.
+        if grammar_config_for_prompt:
             user_prompt = build_grammar_user_prompt(
                 situation.title, conversation.used_spoken_word_ids or [],
-                user_transcript, grammar_config,
+                user_transcript, grammar_config_for_prompt,
             )
         else:
-            system_prompt = get_conversation_system_prompt(
-                language_mode, alt_language=alt_language,
-                animation_type=situation.animation_type if situation else "",
-                situation_id=conversation.situation_id,
-            ) + word_guidance_system
             user_prompt = build_conversation_prompt(
                 situation.title, words, conversation.used_spoken_word_ids or [],
                 user_transcript, alt_language=alt_language,
@@ -1062,8 +756,6 @@ async def voice_turn_respond(
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
         ]
-        if grammar_inject_message:
-            llm_messages.append({"role": "assistant", "content": grammar_inject_message})
 
     # TTS voice config
     tts_voice, tts_instructions = get_tts_instructions(
@@ -1104,13 +796,26 @@ async def voice_turn_respond(
                     }) + "\n"
 
                 elif event["type"] == "done":
-                    # Refresh conversation from DB to ensure we have latest used_spoken_word_ids
+                    # Refresh conversation from DB to ensure we have latest
+                    # used_spoken_word_ids and the stuck counter persist_turn
+                    # just bumped.
                     db.refresh(conversation)
-                    conv_complete, _ = check_completion(conversation)
+                    # Grammar chats with a chip snapshot complete only when
+                    # every chip ticks; vocab/non-chat grammar fall back to
+                    # the legacy infinitive-coverage check.
+                    if conversation.chat_target_forms_json:
+                        conv_complete = chip_complete or (
+                            conversation.turn_count or 0
+                        ) >= EXCHANGE_HARD_LIMIT
+                    else:
+                        conv_complete, _ = check_completion(conversation)
                     logger.info(
                         f"[Voice Turn] Completion check: target={conversation.target_word_ids}, "
-                        f"spoken={conversation.used_spoken_word_ids}, turns={conversation.turn_count}, "
-                        f"complete={conv_complete}"
+                        f"spoken={conversation.used_spoken_word_ids}, "
+                        f"chips_done={len(completed_chip_ids)}/"
+                        f"{len(conversation.chat_target_forms_json or [])}, "
+                        f"no_progress={conversation.consecutive_no_progress_turns}, "
+                        f"turns={conversation.turn_count}, complete={conv_complete}"
                     )
                     if conv_complete:
                         conversation.status = "complete"
@@ -1123,6 +828,8 @@ async def voice_turn_respond(
                     yield json_module.dumps({
                         "type": "done",
                         "conversation_complete": conv_complete,
+                        "completed_chip_ids": completed_chip_ids,
+                        "consecutive_no_progress_turns": conversation.consecutive_no_progress_turns or 0,
                     }) + "\n"
 
         except Exception as e:
@@ -1185,7 +892,16 @@ async def realtime_turn(
         alt_language=current_user.alt_language,
     )
 
-    complete, turns_remaining = check_completion(conversation)
+    # Grammar chats with a chip snapshot complete only when every chip ticks;
+    # vocab/non-chat grammar fall back to the legacy infinitive-coverage check.
+    if conversation.chat_target_forms_json:
+        chips_total = len(conversation.chat_target_forms_json or [])
+        chips_done = len(conversation.completed_chip_ids or [])
+        chip_complete = chips_total > 0 and chips_done >= chips_total
+        _, turns_remaining = check_completion(conversation)
+        complete = chip_complete or (conversation.turn_count or 0) >= EXCHANGE_HARD_LIMIT
+    else:
+        complete, turns_remaining = check_completion(conversation)
     if complete and conversation.status != "complete":
         conversation.status = "complete"
         conversation.completed_at = datetime.now(timezone.utc)
@@ -1198,6 +914,8 @@ async def realtime_turn(
         missing_word_ids=missing_word_ids,
         conversation_complete=complete,
         turns_remaining=turns_remaining,
+        completed_chip_ids=list(conversation.completed_chip_ids or []),
+        consecutive_no_progress_turns=conversation.consecutive_no_progress_turns or 0,
     )
 
 

--- a/app/api/v1/situations.py
+++ b/app/api/v1/situations.py
@@ -441,7 +441,11 @@ async def get_situation(
             )
 
     # Select and sort words
-    encounter_word_ids, high_freq_word_ids = select_words_for_situation(db, current_user.id, situation_id)
+    encounter_word_ids, high_freq_word_ids = select_words_for_situation(
+        db, current_user.id, situation_id,
+        vocab_level=get_vocab_level(db, current_user.id),
+        spanish_level=current_user.q0_spanish_level,
+    )
     target_word_ids = encounter_word_ids + high_freq_word_ids
     words = db.query(Word).filter(Word.id.in_(target_word_ids)).all()
     final_words = sort_words_encounter_first(words, situation_id, db, target_word_ids)
@@ -508,7 +512,11 @@ async def start_situation(
         words = get_words_by_ids(db, target_word_ids)
     else:
         # Create new conversation with word selection
-        encounter_word_ids, high_freq_word_ids = select_words_for_situation(db, current_user.id, situation_id)
+        encounter_word_ids, high_freq_word_ids = select_words_for_situation(
+        db, current_user.id, situation_id,
+        vocab_level=get_vocab_level(db, current_user.id),
+        spanish_level=current_user.q0_spanish_level,
+    )
         target_word_ids = encounter_word_ids + high_freq_word_ids
         words = db.query(Word).filter(Word.id.in_(target_word_ids)).all()
 
@@ -651,7 +659,11 @@ async def admin_skip_encounter(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Situation not found")
 
     # 1. Select words (reuses existing logic)
-    encounter_word_ids, hf_word_ids = select_words_for_situation(db, current_user.id, situation_id)
+    encounter_word_ids, hf_word_ids = select_words_for_situation(
+        db, current_user.id, situation_id,
+        vocab_level=get_vocab_level(db, current_user.id),
+        spanish_level=current_user.q0_spanish_level,
+    )
     target_word_ids = encounter_word_ids + hf_word_ids
     words = db.query(Word).filter(Word.id.in_(target_word_ids)).all()
 

--- a/app/models.py
+++ b/app/models.py
@@ -188,6 +188,27 @@ class Conversation(Base):
     # Per-conversation counter for "Need help?" sentence hints. Capped by
     # sentence_hint_service to prevent farming. Migration 026.
     sentence_hints_used = Column(Integer, default=0, nullable=False, server_default="0")
+    # Counts user turns since the last new target was detected. Reset to 0 on
+    # any turn that adds a fresh id to `used_spoken_word_ids`; incremented
+    # otherwise. Drives the v3 system prompt's anti-stuck rule and the FE's
+    # "Need help?" nudge toast.
+    consecutive_no_progress_turns = Column(
+        Integer, default=0, nullable=False, server_default="0",
+    )
+    # Snapshot of the FE's per-(verb, pronoun) chip list for grammar chat
+    # lessons (`*_chat` situations). Populated at conversation creation from
+    # `get_chat_target_forms`; used by `check_chat_chip_completion` so the
+    # backend gates completion on the same chips the FE shows. NULL for
+    # vocab encounters and non-chat grammar — those keep the legacy
+    # infinitive-level completion path.
+    chat_target_forms_json = Column(JSONB, nullable=True)
+    # Cumulative set of chip ids ticked across all turns. Updated by
+    # `voice_turn_service.persist_turn` (ANY voice turn — legacy or realtime),
+    # so the FE can render green checks straight from the API response and the
+    # `/realtime-turn` flow stays history-free.
+    completed_chip_ids = Column(
+        JSONB, default=list, nullable=False, server_default="'[]'::jsonb",
+    )
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
     completed_at = Column(DateTime(timezone=True), nullable=True)

--- a/app/prompts/prompts.json
+++ b/app/prompts/prompts.json
@@ -1,9 +1,17 @@
 {
   "conversation_agent": {
+    "prompt_version": "v3",
+    "content": "You are {ai_role}, speaking to {user_role}. {situation_description}\n\nSpeak in {language} and not in any other language. Always use correct pronouns — if the student uses the wrong one, recast with the correct pronoun in your reply without explaining the mistake.\n\n{goal_block}{level_rule}\n\nTARGET STEERING — your most important job:\nThe student is shown a panel of pending items they must produce. Pick ONE item per turn from the list below. Ask a question whose natural answer is exactly that item (or contains it). DO NOT produce the target form yourself in your reply. If the student answers without using the target, on your NEXT turn make the elicitation more explicit (offer a contrast, e.g. 'Yo escucho rock — ¿y tú?').\n\nPending items (pick ONE per turn):\n{target_steering}\n\n{anti_stuck_rule}\n\nFORBIDDEN:\n- Never explain grammar rules.\n- Never list the chips or call them \"chips\", \"items\", \"targets\", or \"words\".\n- Never break the roleplay.\n- 1–2 sentences per turn, max."
+  },
+  "grammar_agent": {
+    "prompt_version": "v3",
+    "content": "You are a grammar practice partner. Speak in {language} and not in any other language.\n\n{goal_block}{level_rule}\n\nTARGET STEERING — your most important job:\nThe student is shown a panel of conjugation chips they must produce. Pick ONE chip per turn from the list below. Use the suggested elicitation frame as a starting point — adapt it to fit your scene and the conversation history. The student must say the EXACT Spanish form to tick the chip. DO NOT say the target form yourself in your reply.\n\nIf the student uses the wrong pronoun, recast with the correct one instead of explaining — model the form, don't teach it.\n\nPending chips (pick ONE per turn):\n{target_steering}\n\n{anti_stuck_rule}\n\nRules:\n- One short question per turn (1 sentence max).\n- If the student answers correctly, briefly acknowledge then ask the next chip.\n- Never explain grammar rules.\n- Never list the chips or call them \"chips\", \"items\", \"targets\", or \"words\".\n- Never break the roleplay."
+  },
+  "conversation_agent_v2": {
     "prompt_version": "v2",
     "content": "You are {ai_role}, speaking to {user_role}. {situation_description}\n\nSpeak in {language} and not in any other language. Always use correct pronouns — if the student uses the wrong one, recast with the correct pronoun in your reply without explaining the mistake. 1-2 sentences max."
   },
-  "grammar_agent": {
+  "grammar_agent_v2": {
     "prompt_version": "v2",
     "content": "You are a grammar practice partner. Speak in {language} and not in any other language.\n\nRules:\n- One short question per turn (1 sentence max)\n- If the student answers correctly, briefly acknowledge then ask the next question\n- If the student uses the wrong pronoun, recast with the correct one instead of explaining — model the form, don't teach it\n- Follow the targeting instructions in your assistant messages exactly"
   }

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -357,6 +357,15 @@ class RealtimeTurnResponse(BaseModel):
     # "N turns left" warning. Pinned to 0 once past the threshold; the hard
     # limit at 30 is what actually flips `conversation_complete`.
     turns_remaining: int
+    # Cumulative chip ids ticked across all turns in this conversation.
+    # Empty for vocab encounters and non-chat grammar lessons (those
+    # surface progress through `detected_word_ids` instead). FE consumes
+    # this directly so chip ticks survive a page refresh and don't drift
+    # from the BE's view.
+    completed_chip_ids: List[str] = Field(default_factory=list)
+    # Turns since the learner last produced a new target. Drives the FE's
+    # "Need help?" nudge toast at >= 2.
+    consecutive_no_progress_turns: int = 0
 
 
 # Grammar config schemas

--- a/app/services/conversation_service.py
+++ b/app/services/conversation_service.py
@@ -1,10 +1,28 @@
 import logging
+import re
+import unicodedata
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects.postgresql import insert
 from app.models import Conversation, UserWord, Word
-from typing import List
+from typing import Iterable, List, Tuple
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_for_match(text: str) -> str:
+    """Lowercase + strip punctuation + drop diacritics for chip matching.
+
+    Mirrors `app/services/word_detection.normalize_text` so chip detection
+    treats accents and casing the same way the per-verb infinitive
+    detection does. Kept private here because it has one consumer
+    (`check_chat_chip_completion`) and importing the public version
+    would create a circular import on this module.
+    """
+    text = text.lower()
+    text = re.sub(r"[^\w\s]", " ", text)
+    text = unicodedata.normalize("NFD", text)
+    text = "".join(c for c in text if unicodedata.category(c) != "Mn")
+    return text
 
 
 def check_conversation_complete(conversation: Conversation, mode: str) -> bool:
@@ -83,11 +101,68 @@ def get_missing_word_ids(conversation: Conversation, mode: str) -> List[str]:
         used_word_ids = set(conversation.used_typed_word_ids or [])
     else:  # voice
         used_word_ids = set(conversation.used_spoken_word_ids or [])
-    
+
     target_word_ids = set(conversation.target_word_ids or [])
     missing = target_word_ids - used_word_ids
-    
+
     return list(missing)
+
+
+def check_chat_chip_completion(
+    conversation: Conversation,
+    user_transcripts: Iterable[str],
+) -> Tuple[bool, List[str]]:
+    """Per-chip completion check for grammar `*_chat` lessons.
+
+    Vocab encounters and non-chat grammar lessons keep the legacy
+    `check_conversation_complete` path (`target_word_ids` ⊆
+    `used_spoken_word_ids`). Chat lessons need finer granularity: the FE
+    shows a sample of 8 (verb, pronoun) chips and the conversation
+    should not complete until each chip has actually been uttered. The
+    server-side snapshot of those chips lives in
+    `Conversation.chat_target_forms_json`; we scan the user's full
+    transcript log for each chip's exact `spanish` form (word-boundary,
+    accent-insensitive) and report which chip ids are now ticked.
+
+    Returns `(complete, completed_chip_ids)`. `complete` is True only
+    when every chip has been ticked. Returns `(False, [])` when the
+    conversation has no chip snapshot — caller should fall back to the
+    legacy completion check.
+    """
+    chips = conversation.chat_target_forms_json or []
+    if not chips:
+        return False, []
+
+    haystack = " ".join(_normalize_for_match(t or "") for t in user_transcripts)
+    if not haystack:
+        return False, []
+
+    completed: List[str] = []
+    for chip in chips:
+        spanish = chip.get("spanish") or ""
+        # Persistence stores the FE chip id alongside the form so the BE
+        # never has to synthesize one. Fall back to `form:{spanish}:{pronoun}`
+        # for older rows that pre-date the id field — same convention the
+        # FE uses in ImmersiveVoiceScene.applyDetectedWords.
+        chip_id = chip.get("id") or chip.get("chip_id")
+        if not chip_id and spanish:
+            pronoun = chip.get("pronoun") or ""
+            chip_id = f"form:{spanish}:{pronoun}"
+        if not spanish or not chip_id:
+            continue
+        normalized = _normalize_for_match(spanish)
+        if not normalized:
+            continue
+        if " " in normalized:
+            if normalized in haystack:
+                completed.append(chip_id)
+        else:
+            pattern = r"\b" + re.escape(normalized) + r"\b"
+            if re.search(pattern, haystack):
+                completed.append(chip_id)
+
+    complete = len(completed) == len(chips)
+    return complete, completed
 
 
 

--- a/app/services/grammar_elicitation.py
+++ b/app/services/grammar_elicitation.py
@@ -1,0 +1,105 @@
+"""Spanish-language elicitation frames for grammar chat targeting.
+
+Replaces the previous English-hardcoded `_build_grammar_hint` dict
+(370+ lines of `(verb, pronoun) → English question` overrides) with a
+small set of Spanish frames keyed by pronoun and parameterised on the
+verb's English lemma. The avatar speaks Spanish in roleplay, so its
+"what should I ask next" hint should be in Spanish too — feeding it
+English think-aloud caused the model to leak English into its reply
+and made the elicitation feel mechanical.
+
+These frames are not a rigid script. They go into the v3 system prompt
+under the target-steering block as suggestions; the LLM adapts them to
+the scene and the conversation history.
+"""
+from __future__ import annotations
+
+from typing import List
+
+from app.data.grammar_situations import GRAMMAR_WORD_TRANSLATIONS
+from app.services.learner_context import ChipTarget
+
+
+# Each frame sets up a question whose natural answer uses the target
+# (verb, pronoun) form. The Spanish frame stays roleplay-natural; the
+# `[verb in {pronoun}]` slot is left as an English directive so the LLM
+# fills it with the contextually-appropriate Spanish form when it
+# speaks. Frames are deliberately short — the LLM has freedom to
+# decorate them with scene context (a restaurant waiter, a neighbour,
+# etc.).
+PRONOUN_ELICITATION_FRAMES: dict[str, str] = {
+    "yo":       "Yo siempre [{bare_lemma} in 1st person]. ¿Y tú?",
+    "tú":       "Cuéntame, ¿tú [{bare_lemma} in tú form]?",
+    "él":       "Y tu hermano, ¿[{bare_lemma} in 3rd person sing.]?",
+    "ella":     "Y tu hermana, ¿[{bare_lemma} in 3rd person sing.]?",
+    "usted":    "Y usted, ¿[{bare_lemma} in usted form]?",
+    "nosotros": "Tus amigos y tú, ¿[{bare_lemma} in nosotros form]?",
+    "nosotras": "Tus hermanas y tú, ¿[{bare_lemma} in nosotras form]?",
+    "ellos":    "Tus amigos, ¿[{bare_lemma} in ellos form]?",
+    "ellas":    "Tus amigas, ¿[{bare_lemma} in ellas form]?",
+    "ustedes":  "Y ustedes, ¿[{bare_lemma} in ustedes form]?",
+}
+
+
+def _strip_to(lemma_en: str) -> str:
+    """Drop a leading 'to ' and return the bare verb."""
+    base = lemma_en.lower().strip()
+    if base.startswith("to "):
+        base = base[3:]
+    base = base.split("/")[0].strip()  # "drink/take" → "drink"
+    base = base.split(" or ")[0].strip()
+    base = base.split("(")[0].strip()
+    return base
+
+
+def _frame_for_chip(chip: ChipTarget) -> str:
+    """Render the elicitation frame for one grammar chip.
+
+    Falls back to a generic prompt if the pronoun isn't in the frame
+    table — keeps the prompt usable for any future pronouns we add.
+    """
+    pronoun = chip.pronoun or "tú"
+    verb = chip.verb or chip.spanish
+    en_lemma_full = GRAMMAR_WORD_TRANSLATIONS.get(verb, verb)
+    bare_lemma = _strip_to(en_lemma_full)
+
+    template = PRONOUN_ELICITATION_FRAMES.get(
+        pronoun,
+        "Cuéntame, ¿[{bare_lemma} in {pronoun} form]?",
+    )
+    return template.format(bare_lemma=bare_lemma, pronoun=pronoun)
+
+
+def format_target_steering(
+    chips: List[ChipTarget],
+    completed_chip_ids: List[str],
+) -> str:
+    """Render the target-steering block dropped into the v3 system prompt.
+
+    Returns a multi-line string listing pending chips numbered 1..N with
+    the EXACT Spanish form, English gloss, and (for grammar chips) a
+    Spanish elicitation frame the LLM can adapt. Returns an empty
+    string when there are no pending chips — the caller should omit the
+    section entirely in that case.
+
+    The block intentionally does NOT include already-completed chips —
+    surfacing them invites the model to repeat words the learner has
+    already mastered in this conversation.
+    """
+    completed = set(completed_chip_ids)
+    pending = [c for c in chips if c.id not in completed]
+    if not pending:
+        return ""
+
+    lines: List[str] = []
+    for idx, chip in enumerate(pending, start=1):
+        if chip.is_grammar:
+            frame = _frame_for_chip(chip)
+            lines.append(
+                f"{idx}. {chip.spanish} ({chip.english} — verb "
+                f"'{chip.verb}' in {chip.pronoun}). "
+                f"Elicit with: {frame}"
+            )
+        else:
+            lines.append(f"{idx}. {chip.spanish} ({chip.english})")
+    return "\n".join(lines)

--- a/app/services/learner_context.py
+++ b/app/services/learner_context.py
@@ -1,0 +1,61 @@
+"""Learner-aware context carried into the conversation/grammar system prompts.
+
+The v3 prompts in `app/prompts/prompts.json` need more than the current
+persona — they need to know the learner's level, what chips the FE is
+showing, which are already green, the conversation goal, and whether
+the learner is stuck. Centralising those fields in a dataclass keeps
+the prompt builders' signatures sane and makes the contract obvious to
+every call-site (legacy `/voice-turn` and the WebRTC realtime ephemeral
+session both must populate the same shape — divergence between them is
+how the realtime flow drifted from the legacy one in the past).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class ChipTarget:
+    """One item in the FE's "Use these words to progress" panel.
+
+    For vocab encounters, `verb`/`pronoun` are None and `spanish` is the
+    word/phrase the learner must utter. For grammar chats the chip is a
+    specific (verb, pronoun) conjugation — `spanish` is the conjugated
+    form (e.g. "cantas") and `english` is the conjugated English gloss
+    ("you sing").
+    """
+
+    id: str
+    spanish: str
+    english: str
+    verb: Optional[str] = None
+    pronoun: Optional[str] = None
+
+    @property
+    def is_grammar(self) -> bool:
+        return self.verb is not None and self.pronoun is not None
+
+
+@dataclass
+class LearnerContext:
+    """Everything the v3 system prompt needs about the learner + lesson.
+
+    Fields default to "no information" so legacy call-sites that haven't
+    been updated yet still produce a usable prompt — they just lose the
+    level adaptation, goal, and anti-stuck behaviour. The prompt builder
+    omits sections whose inputs are empty/None.
+    """
+
+    spanish_level: Optional[str] = None  # "a"|"b"|"c"|"d" (q0_spanish_level)
+    vocab_level: int = 0
+    grammar_level: float = 0.0
+    goal: Optional[str] = None
+    target_chips: List[ChipTarget] = field(default_factory=list)
+    completed_chip_ids: List[str] = field(default_factory=list)
+    consecutive_no_progress_turns: int = 0
+
+    def pending_chips(self) -> List[ChipTarget]:
+        """Chips not yet ticked. Order preserved from `target_chips`."""
+        completed = set(self.completed_chip_ids)
+        return [c for c in self.target_chips if c.id not in completed]

--- a/app/services/learner_level.py
+++ b/app/services/learner_level.py
@@ -1,0 +1,92 @@
+"""Shared level-aware prompt rules keyed on `User.q0_spanish_level`.
+
+The onboarding V2 quiz answer (`a`/`b`/`c`/`d`) maps to a learner-level
+band that we surface to the LLM as a short rule string. Two consumers:
+
+- `sentence_hint_service` — needs a sentence-budget rule (one sentence,
+  word count, allowable subordinates) so the hint stays speakable.
+- The conversation/grammar agents (prompts.json v3) — need a cadence rule
+  governing the AI's own turns (sentence length, complexity, idiom use).
+
+These are deliberately different prompts: a hint is one sentence the
+learner produces; a conversation rule governs the AI's pacing across
+many turns. Sharing a level lookup but separate copy keeps both honest.
+
+Null/unknown levels fall back to `c` (intermediate) — safe middle ground
+for legacy users who never went through V2 onboarding.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+_DEFAULT_LEVEL = "c"
+
+
+def _normalize(spanish_level: Optional[str]) -> str:
+    return (spanish_level or _DEFAULT_LEVEL).lower()
+
+
+def level_rules_for_hint(spanish_level: Optional[str]) -> str:
+    """Sentence-budget rule for `/sentence-hint` generation.
+
+    Returns a single bullet line ready to drop into the hint system
+    prompt. Tighter limits at lower levels because a 14-word hint is
+    unspeakable for an absolute beginner.
+    """
+    level = _normalize(spanish_level)
+    if level == "a":
+        return (
+            "- LEARNER LEVEL: absolute beginner. The sentence MUST be 5–7 words "
+            "and use EXACTLY ONE pending item. No subordinate clauses, no "
+            "compound sentences, no embedded questions. Keep it as simple as "
+            "physically possible to say out loud."
+        )
+    if level == "b":
+        return (
+            "- LEARNER LEVEL: novice. The sentence MUST be 7–9 words and use 1 "
+            "pending item (a second only if it fits naturally). No complex "
+            "subordinates."
+        )
+    if level == "d":
+        return (
+            "- LEARNER LEVEL: advanced. Sentence may be up to ~14 words and "
+            "use 1 or 2 pending items with natural complexity."
+        )
+    return (
+        "- LEARNER LEVEL: intermediate. The sentence MUST be 9–12 words and "
+        "use 1 or 2 pending items. Simple subordinates allowed."
+    )
+
+
+def level_rules_for_conversation(spanish_level: Optional[str]) -> str:
+    """Cadence rule for the conversation/grammar agent's own turns.
+
+    Governs how the AI speaks back: sentence length, complexity, idiom
+    tolerance, speed cues. Separate from `level_rules_for_hint` because
+    the AI is producing many turns in roleplay, not a single sentence
+    the learner must repeat.
+    """
+    level = _normalize(spanish_level)
+    if level == "a":
+        return (
+            "- LEARNER LEVEL: absolute beginner. Speak slowly. 4–6 word "
+            "sentences. One idea per turn. No subordinate clauses, no idioms, "
+            "no slang. Stick to present tense verbs the learner has seen."
+        )
+    if level == "b":
+        return (
+            "- LEARNER LEVEL: novice. 6–9 word sentences. Avoid compound "
+            "clauses. No idioms or regional slang. Repeat key nouns rather "
+            "than using pronouns the learner may not catch."
+        )
+    if level == "d":
+        return (
+            "- LEARNER LEVEL: advanced. Speak normally but clearly. Natural "
+            "sentence length is fine; idioms and varied tenses welcome. "
+            "Push the learner with follow-ups."
+        )
+    return (
+        "- LEARNER LEVEL: intermediate. Natural sentences but no idioms or "
+        "optional subjunctive. Keep clauses short — one subordinate max."
+    )

--- a/app/services/realtime_config.py
+++ b/app/services/realtime_config.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import Session
 from app.data.grammar_situations import get_grammar_config
 from app.models import Conversation, Situation
 from app.services.alt_language_service import get_target_language_name
+from app.services.learner_context import LearnerContext
 from app.services.voice_turn_service import (
     build_grammar_system_prompt,
     get_conversation_system_prompt,
@@ -84,6 +85,7 @@ def _resolve_system_prompt(
     alt_language: Optional[str],
     vocab_level: int,
     grammar_level: float,
+    learner_ctx: Optional[LearnerContext] = None,
 ) -> str:
     """Build the system prompt the model should carry for the whole session.
 
@@ -91,6 +93,11 @@ def _resolve_system_prompt(
     existing message history: pick grammar template if the situation is a
     grammar drill, otherwise the conversation template. Alt-language mode
     swaps the language_mode suffix so prompts render in Catalan/Swedish.
+
+    `learner_ctx` is forwarded into the v3 templates. Optional so the
+    legacy session-mint path keeps working until callers populate it,
+    but production should pass a populated context — without it, the
+    target-steering block degrades to a placeholder line.
     """
     language_mode = get_language_mode(
         situation.encounter_number, vocab_level, grammar_level
@@ -103,12 +110,14 @@ def _resolve_system_prompt(
             conversation.situation_id,
             language_mode=language_mode,
             alt_language=alt_language,
+            learner_ctx=learner_ctx,
         )
     return get_conversation_system_prompt(
         language_mode=language_mode,
         alt_language=alt_language,
         animation_type=situation.animation_type,
         situation_id=conversation.situation_id,
+        learner_ctx=learner_ctx,
     )
 
 
@@ -120,6 +129,7 @@ def build_session_config(
     alt_language: Optional[str] = None,
     vocab_level: int = 0,
     grammar_level: float = 0.0,
+    learner_ctx: Optional[LearnerContext] = None,
     mode: Literal["ephemeral", "server_ws"] = "ephemeral",
 ) -> dict:
     """Assemble the Realtime session configuration for a conversation.
@@ -166,7 +176,8 @@ def build_session_config(
         situation_id=situation.id,
     )
     system_prompt = _resolve_system_prompt(
-        conversation, situation, alt_language, vocab_level, grammar_level
+        conversation, situation, alt_language, vocab_level, grammar_level,
+        learner_ctx=learner_ctx,
     )
 
     base = {

--- a/app/services/sentence_hint_service.py
+++ b/app/services/sentence_hint_service.py
@@ -36,6 +36,7 @@ from app.services.alt_language_service import (
     get_target_language_name,
 )
 from app.services.conversation_service import get_missing_word_ids
+from app.services.learner_level import level_rules_for_hint
 from app.services.llm_gateway import ConversationContext, generate_conversation
 from app.services.openai_media_gateway import synthesize_speech as gateway_synthesize_speech
 from app.services.word_detection import get_words_by_ids
@@ -162,39 +163,6 @@ def _grammar_pending_items(
     return items
 
 
-def _level_rules(spanish_level: Optional[str]) -> str:
-    """Length/complexity rule for the prompt, keyed on q0_spanish_level.
-
-    A 14-word hint is unspeakable for an absolute beginner, so we tighten
-    word budget and forbid subordinates as the level drops. Null/unknown
-    falls back to 'c' (intermediate) — safe middle ground for legacy
-    users who never went through V2 onboarding.
-    """
-    level = (spanish_level or "c").lower()
-    if level == "a":
-        return (
-            "- LEARNER LEVEL: absolute beginner. The sentence MUST be 5–7 words "
-            "and use EXACTLY ONE pending item. No subordinate clauses, no "
-            "compound sentences, no embedded questions. Keep it as simple as "
-            "physically possible to say out loud."
-        )
-    if level == "b":
-        return (
-            "- LEARNER LEVEL: novice. The sentence MUST be 7–9 words and use 1 "
-            "pending item (a second only if it fits naturally). No complex "
-            "subordinates."
-        )
-    if level == "d":
-        return (
-            "- LEARNER LEVEL: advanced. Sentence may be up to ~14 words and "
-            "use 1 or 2 pending items with natural complexity."
-        )
-    return (
-        "- LEARNER LEVEL: intermediate. The sentence MUST be 9–12 words and "
-        "use 1 or 2 pending items. Simple subordinates allowed."
-    )
-
-
 def build_hint_messages(
     pending_items: List[PendingItem],
     recent_messages: Optional[List[Dict[str, str]]],
@@ -214,7 +182,7 @@ def build_hint_messages(
     history_block = _format_history_for_prompt(recent_messages or [])
 
     title = situation_title or "this conversation"
-    level_rule = _level_rules(spanish_level)
+    level_rule = level_rules_for_hint(spanish_level)
 
     # The learner is stuck in a real roleplay and needs help unblocking
     # the conversation. The prompt deliberately fights the model's
@@ -243,7 +211,17 @@ def build_hint_messages(
         "    GOOD: \"Aquí tiene mi pasaporte, ¿lo ve bien?\"\n"
         "- pending: mesa, reservar\n"
         "    BAD:  \"Quiero una mesa.\"\n"
-        "    GOOD: \"Tengo una reserva a las ocho, ¿la mesa está lista?\"\n\n"
+        "    GOOD: \"Tengo una reserva a las ocho, ¿la mesa está lista?\"\n"
+        # Grammar examples — the learner's chips are conjugated forms (cantas,
+        # escucho, vivimos), not infinitives. The model's default move is to
+        # reach for the infinitive ('Quiero cantar') which defeats the chip;
+        # these few-shots ground it on producing the exact conjugation.\n"
+        "- pending: cantas, escucho, hablan\n"
+        "    BAD:  \"Quiero cantar en el coche.\"   (infinitive — chip stays grey)\n"
+        "    GOOD: \"Yo escucho rock en la mañana. ¿Tú cantas algo?\"\n"
+        "- pending: vivimos, comen\n"
+        "    BAD:  \"Vivir aquí es bueno y comer también.\"   (infinitives, no chips)\n"
+        "    GOOD: \"Mi familia y yo vivimos cerca. ¿Tus amigos comen aquí?\"\n\n"
         "Rules:\n"
         "- ONE sentence, first person — the LEARNER is the speaker.\n"
         f"{level_rule}\n"

--- a/app/services/voice_turn_service.py
+++ b/app/services/voice_turn_service.py
@@ -11,6 +11,9 @@ from app.data.situation_roles import (
     GRAMMAR_SCENE_MAP,
 )
 from app.services.alt_language_service import get_target_language_name
+from app.services.grammar_elicitation import format_target_steering
+from app.services.learner_context import LearnerContext
+from app.services.learner_level import level_rules_for_conversation
 
 
 # Hard limit on persisted turns per voice conversation. Mirrors the FE's
@@ -40,40 +43,102 @@ def is_advanced_mode(language_mode: str) -> bool:
     )
 
 
+_STUCK_THRESHOLD_NUDGE = 2
+_STUCK_THRESHOLD_TRANSLATE = 3
+
+
+def _render_goal_block(goal: Optional[str]) -> str:
+    if not goal:
+        return ""
+    return f"Your job is to make the student arrive at this outcome: {goal}\n\n"
+
+
+def _render_anti_stuck_rule(consecutive_no_progress_turns: int) -> str:
+    """Inject a stronger scaffolding directive once the learner has skipped
+    the target multiple turns in a row.
+
+    Below the nudge threshold the section is empty so the prompt isn't
+    polluted on the first turn of every conversation. Above the
+    translate threshold we authorise the AI to gloss the target form in
+    English parentheses — a last resort that keeps the lesson moving.
+    """
+    n = consecutive_no_progress_turns or 0
+    if n < _STUCK_THRESHOLD_NUDGE:
+        return ""
+    if n < _STUCK_THRESHOLD_TRANSLATE:
+        return (
+            f"ANTI-STUCK: the student has skipped the target {n} turns in a row. "
+            "Drop one level of indirectness — ask a fill-in-style question or a "
+            "yes/no with the target form embedded ('¿Tú cantas o no cantas?')."
+        )
+    return (
+        f"ANTI-STUCK: the student has skipped the target {n} turns in a row. "
+        "Drop indirectness completely — translate the target form into English "
+        "in parentheses inside your question, e.g. '¿Tú cantas (do you sing) "
+        "en la ducha?'."
+    )
+
+
+def _render_target_steering(learner_ctx: Optional[LearnerContext]) -> str:
+    if not learner_ctx:
+        return "(no pending items — keep the conversation flowing naturally)"
+    block = format_target_steering(
+        learner_ctx.target_chips, learner_ctx.completed_chip_ids,
+    )
+    return block or "(all items complete — wrap up the conversation gracefully)"
+
+
 def build_system_prompt(
     animation_type: str,
     situation_id: str,
     language_mode: str = "spanish_text",
     alt_language: Optional[str] = None,
+    learner_ctx: Optional[LearnerContext] = None,
 ) -> str:
     """Build the system prompt for conversation or grammar agents.
 
     Uses role data from situation_roles.py and templates from prompts.json.
     Always uses target-language prompts (no beginner English mode).
+
+    `learner_ctx` carries level / goal / chip targeting / stuck counter
+    into the v3 templates. Optional for backwards compatibility — when
+    omitted, the level rule defaults to intermediate, the goal/anti-stuck
+    sections collapse to empty strings, and target steering shows a
+    placeholder line. Every production call-site should populate it.
     """
     from app.services.llm_gateway import load_prompt
 
     language = get_target_language_name(alt_language)
     roles = get_roles_for_situation(animation_type, situation_id)
 
-    # Check if this is a grammar situation
     grammar_struct = get_grammar_structure(situation_id)
     grammar_config = get_grammar_config(situation_id)
 
+    spanish_level = learner_ctx.spanish_level if learner_ctx else None
+    goal = learner_ctx.goal if learner_ctx else None
+    no_progress_turns = (
+        learner_ctx.consecutive_no_progress_turns if learner_ctx else 0
+    )
+
+    common_kwargs = {
+        "language": language,
+        "goal_block": _render_goal_block(goal),
+        "level_rule": level_rules_for_conversation(spanish_level),
+        "target_steering": _render_target_steering(learner_ctx),
+        "anti_stuck_rule": _render_anti_stuck_rule(no_progress_turns),
+    }
+
     if grammar_struct or grammar_config:
-        template = load_prompt("grammar_agent", "v2")
-        try:
-            return template.format(language=language)
-        except KeyError:
-            return template
-    else:
-        template = load_prompt("conversation_agent", "v2")
-        return template.format(
-            ai_role=roles["ai_role"],
-            user_role=roles["user_role"],
-            situation_description=roles["situation_description"],
-            language=language,
-        )
+        template = load_prompt("grammar_agent", "v3")
+        return template.format(**common_kwargs)
+
+    template = load_prompt("conversation_agent", "v3")
+    return template.format(
+        ai_role=roles["ai_role"],
+        user_role=roles["user_role"],
+        situation_description=roles["situation_description"],
+        **common_kwargs,
+    )
 
 
 def build_transcription_prompt(situation_title: str, words: List[Word], alt_language: Optional[str] = None) -> str:
@@ -94,14 +159,22 @@ def build_transcription_prompt(situation_title: str, words: List[Word], alt_lang
 
 # ── Legacy functions (kept for backward compatibility during transition) ──────
 
-def build_grammar_system_prompt(situation_id: str, language_mode: str = "spanish_text", alt_language: Optional[str] = None) -> Optional[str]:
+def build_grammar_system_prompt(
+    situation_id: str,
+    language_mode: str = "spanish_text",
+    alt_language: Optional[str] = None,
+    learner_ctx: Optional[LearnerContext] = None,
+) -> Optional[str]:
     """Build a system prompt for grammar conversation phases (2/3)."""
     config = get_grammar_config(situation_id)
     if not config:
         return None
     if alt_language and language_mode in ("spanish_text", "spanish_audio"):
         language_mode = language_mode.replace("spanish_", f"{alt_language}_")
-    return build_system_prompt("grammar", situation_id, language_mode, alt_language)
+    return build_system_prompt(
+        "grammar", situation_id, language_mode, alt_language,
+        learner_ctx=learner_ctx,
+    )
 
 
 def build_grammar_user_prompt(
@@ -127,9 +200,13 @@ def get_conversation_system_prompt(
     alt_language: Optional[str] = None,
     animation_type: str = "",
     situation_id: str = "",
+    learner_ctx: Optional[LearnerContext] = None,
 ) -> str:
     """Build the conversation system prompt with role context."""
-    return build_system_prompt(animation_type, situation_id, language_mode, alt_language)
+    return build_system_prompt(
+        animation_type, situation_id, language_mode, alt_language,
+        learner_ctx=learner_ctx,
+    )
 
 
 def build_conversation_prompt(
@@ -242,10 +319,39 @@ def persist_turn(
     detected_word_ids = detect_words(db, conversation, user_transcript, alt_language)
 
     was_empty = len(conversation.used_spoken_word_ids or []) == 0
-    current_used = set(conversation.used_spoken_word_ids or [])
+    used_before = set(conversation.used_spoken_word_ids or [])
+    current_used = set(used_before)
     current_used.update(detected_word_ids)
     conversation.used_spoken_word_ids = list(current_used)
     conversation.turn_count = (conversation.turn_count or 0) + 1
+
+    # Chip-level progress for grammar chats. Scan THIS turn's transcript for
+    # any chip's exact Spanish form and union into completed_chip_ids — the
+    # column is the source of truth so /realtime-turn doesn't need history.
+    new_chip_ids: set[str] = set()
+    if conversation.chat_target_forms_json:
+        from app.services.conversation_service import check_chat_chip_completion
+
+        _, ticked_this_turn = check_chat_chip_completion(
+            conversation, [user_transcript or ""],
+        )
+        chips_before = set(conversation.completed_chip_ids or [])
+        new_chip_ids = set(ticked_this_turn) - chips_before
+        if new_chip_ids:
+            conversation.completed_chip_ids = list(chips_before | new_chip_ids)
+
+    # Stuck counter: any turn that adds a brand-new id to used_spoken_word_ids
+    # OR a brand-new chip is "progress" and resets the counter. Otherwise we
+    # tick up so the v3 system prompt's anti-stuck rule can kick in once the
+    # learner has been missing the target a few turns in a row.
+    new_word_ids = set(detected_word_ids) - used_before
+    progress = bool(new_word_ids or new_chip_ids)
+    if progress:
+        conversation.consecutive_no_progress_turns = 0
+    else:
+        conversation.consecutive_no_progress_turns = (
+            conversation.consecutive_no_progress_turns or 0
+        ) + 1
 
     if detected_word_ids:
         update_user_word_stats(db, str(user_id), detected_word_ids, "voice")

--- a/app/services/word_selection_service.py
+++ b/app/services/word_selection_service.py
@@ -1,7 +1,19 @@
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects.postgresql import insert
 from app.models import Word, Situation, SituationWord, UserWord
-from typing import List, Set, Tuple
+from typing import List, Optional, Set, Tuple
+
+
+# Cold-start vocab-level floor by q0_spanish_level. The DB-tracked VL is the
+# count of mastered HF words; brand-new users have VL=0 regardless of how
+# much Spanish they actually know. Without this floor a self-reported
+# advanced user gets the same first 2 HF words as a true beginner.
+_LEVEL_VL_FLOOR = {"a": 5, "b": 25, "c": 60, "d": 100}
+
+# How wide a band around the user's VL to search for fresh HF words.
+# `LOW` clamps to >= 1 so we never cycle back to negative ranks.
+_HF_BAND_LOW = 50
+_HF_BAND_HIGH = 100
 
 
 def get_learned_word_ids(db: Session, user_id) -> Set[str]:
@@ -27,17 +39,41 @@ def select_words_for_grammar_situation(
     return grammar_word_ids, []
 
 
+def _resolve_effective_vl(vocab_level: int, spanish_level: Optional[str]) -> int:
+    """Floor the user's effective VL by their self-reported level.
+
+    Brand-new users have DB-tracked `vocab_level == 0` regardless of how
+    much Spanish they actually know. Without this floor, a self-reported
+    advanced learner ('d') gets the same first 2 HF words as an absolute
+    beginner ('a'). Once they earn a real VL the DB number wins.
+    """
+    if vocab_level > 0:
+        return vocab_level
+    if not spanish_level:
+        return 0
+    return _LEVEL_VL_FLOOR.get(spanish_level.lower(), 0)
+
+
 def select_words_for_situation(
     db: Session,
     user_id,
     situation_id: str,
     encounter_limit: int = 3,
     high_freq_limit: int = 2,
+    *,
+    vocab_level: int = 0,
+    spanish_level: Optional[str] = None,
 ) -> Tuple[List[str], List[str]]:
     """Select encounter + high-frequency words for a situation.
 
     Returns (encounter_word_ids, high_freq_word_ids).
     For grammar situations, returns all grammar words with no high-freq.
+
+    HF selection prefers words near the learner's vocab level (within a
+    [VL-50, VL+100] band) so beginners don't drown in obscure top-1000
+    words and advanced learners don't get given vocabulary they already
+    know. Falls back to the global frequency-rank order when the band
+    doesn't yield enough candidates — never starves a user of HF words.
     """
     situation = db.query(Situation).filter(Situation.id == situation_id).first()
     if situation and situation.situation_type == 'grammar':
@@ -49,13 +85,46 @@ def select_words_for_situation(
     encounter_word_ids = [sw.word_id for sw in situation_words]
 
     learned_word_ids = get_learned_word_ids(db, user_id)
-
-    high_freq_words = db.query(Word).filter(
+    base_filter = [
         Word.word_category == "high_frequency",
-        ~Word.id.in_(learned_word_ids) if learned_word_ids else True,
-    ).order_by(Word.frequency_rank.asc().nullslast()).limit(high_freq_limit).all()
-    high_freq_word_ids = [w.id for w in high_freq_words]
+    ]
+    if learned_word_ids:
+        base_filter.append(~Word.id.in_(learned_word_ids))
 
+    effective_vl = _resolve_effective_vl(vocab_level, spanish_level)
+
+    high_freq_words: list[Word] = []
+    if effective_vl > 0:
+        band_low = max(1, effective_vl - _HF_BAND_LOW)
+        band_high = effective_vl + _HF_BAND_HIGH
+        high_freq_words = (
+            db.query(Word)
+            .filter(
+                *base_filter,
+                Word.frequency_rank.isnot(None),
+                Word.frequency_rank >= band_low,
+                Word.frequency_rank <= band_high,
+            )
+            .order_by(Word.frequency_rank.asc())
+            .limit(high_freq_limit)
+            .all()
+        )
+
+    if len(high_freq_words) < high_freq_limit:
+        already_picked = {w.id for w in high_freq_words}
+        backfill = (
+            db.query(Word)
+            .filter(
+                *base_filter,
+                ~Word.id.in_(already_picked) if already_picked else True,
+            )
+            .order_by(Word.frequency_rank.asc().nullslast())
+            .limit(high_freq_limit - len(high_freq_words))
+            .all()
+        )
+        high_freq_words.extend(backfill)
+
+    high_freq_word_ids = [w.id for w in high_freq_words]
     return encounter_word_ids, high_freq_word_ids
 
 

--- a/migrations/versions/027_avatar_dynamics_progress_tracking.py
+++ b/migrations/versions/027_avatar_dynamics_progress_tracking.py
@@ -1,0 +1,65 @@
+"""Track per-conversation stuck state and chip targets for grammar chats.
+
+Revision ID: 027_avatar_dynamics_progress_tracking
+Revises: 026_sentence_hints
+Create Date: 2026-05-02
+
+Backs the avatar conversation dynamics overhaul:
+
+- `consecutive_no_progress_turns` counts user turns since the last new
+  target was detected. Used by `voice_turn_service.persist_turn` to
+  drive the v3 system prompt's anti-stuck rule and the FE's nudge toast.
+
+- `chat_target_forms_json` snapshots the FE's per-(verb, pronoun) chip
+  list at conversation creation for grammar `*_chat` lessons. Reading
+  it server-side lets `check_chat_chip_completion` gate completion on
+  the same chips the FE shows, so vocab encounters stop \"completing\"
+  before all chips tick green. NULL for vocab encounters and non-chat
+  grammar — those keep the legacy infinitive-level completion path.
+
+Both columns are populated lazily; existing rows default safely.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision = "027_avatar_dynamics_progress_tracking"
+down_revision = "026_sentence_hints"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "consecutive_no_progress_turns",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "chat_target_forms_json",
+            JSONB(),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "completed_chip_ids",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("conversations", "completed_chip_ids")
+    op.drop_column("conversations", "chat_target_forms_json")
+    op.drop_column("conversations", "consecutive_no_progress_turns")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,4 +1,4 @@
-"""Prompt integrity tests for the v2 template prompt system.
+"""Prompt integrity tests for the v3 template prompt system.
 
 Pure Python tests (no DB needed) that validate prompt templates,
 role data, and system prompt generation.
@@ -7,6 +7,7 @@ Run with: python3.11 -m pytest tests/test_prompts.py --noconftest -v
 
 import pytest
 
+from app.services.learner_context import ChipTarget, LearnerContext
 from app.services.llm_gateway import load_prompt
 from app.services.voice_turn_service import (
     get_conversation_system_prompt,
@@ -23,16 +24,16 @@ from app.data.situation_roles import (
 from app.data.grammar_situations import GRAMMAR_SITUATIONS
 
 
-# ── v2 template prompt IDs ──────────────────────────────────────────────────
+# ── v3 template prompt IDs ──────────────────────────────────────────────────
 
-V2_PROMPTS = [
+V3_PROMPTS = [
     "conversation_agent",
     "grammar_agent",
 ]
 
 
 class TestPromptsLoad:
-    @pytest.mark.parametrize("agent_id", V2_PROMPTS)
+    @pytest.mark.parametrize("agent_id", V3_PROMPTS)
     def test_all_prompts_load(self, agent_id):
         """Every prompt template in prompts.json loads successfully."""
         content = load_prompt(agent_id)
@@ -40,21 +41,26 @@ class TestPromptsLoad:
         assert len(content) > 0
 
     def test_conversation_template_has_placeholders(self):
-        """Conversation template contains required placeholders."""
+        """Conversation template contains the v3 placeholder set."""
         content = load_prompt("conversation_agent")
-        assert "{ai_role}" in content
-        assert "{language}" in content
+        for key in (
+            "{ai_role}", "{user_role}", "{situation_description}",
+            "{language}", "{level_rule}", "{target_steering}",
+            "{anti_stuck_rule}", "{goal_block}",
+        ):
+            assert key in content, f"conversation_agent missing {key}"
 
     def test_grammar_template_loads(self):
-        """Grammar template loads and contains key instructions."""
+        """Grammar template loads and exposes the v3 sections."""
         content = load_prompt("grammar_agent")
-        assert "grammar practice" in content.lower()
-        assert "assistant messages" in content.lower()
+        assert "grammar practice partner" in content.lower()
         assert "{language}" in content
+        assert "{level_rule}" in content
+        assert "{target_steering}" in content
 
     def test_templates_speak_in_language(self):
         """Templates use {language} placeholder (always target language, no English mode)."""
-        for agent_id in V2_PROMPTS:
+        for agent_id in V3_PROMPTS:
             content = load_prompt(agent_id)
             assert "{language}" in content, f"{agent_id} missing {{language}}"
             assert "Speak only in English" not in content, f"{agent_id} should not enforce English"
@@ -135,12 +141,28 @@ class TestBuildSystemPrompt:
         prompt = build_system_prompt("banking", "bank_1", "swedish_text", alt_language="swedish")
         assert "Speak in Swedish" in prompt
 
-    def test_grammar_prompt_is_concise(self):
-        """Grammar system prompt is short — targeting is via injected assistant messages."""
-        prompt = build_system_prompt("grammar", "grammar_regular_present_ar_1", "spanish_text", alt_language=None)
-        assert "grammar practice" in prompt.lower()
+    def test_grammar_prompt_targets_in_band(self):
+        """v3 grammar prompt embeds level rule + target steering directly."""
+        ctx = LearnerContext(
+            spanish_level="b",
+            target_chips=[
+                ChipTarget(
+                    id="conj_hablar_yo", spanish="hablo", english="I speak",
+                    verb="hablar", pronoun="yo",
+                ),
+            ],
+            completed_chip_ids=[],
+        )
+        prompt = build_system_prompt(
+            "grammar", "grammar_regular_present_ar_1", "spanish_text",
+            alt_language=None, learner_ctx=ctx,
+        )
+        assert "grammar practice partner" in prompt.lower()
         assert "Speak in Spanish" in prompt
-        assert "assistant messages" in prompt.lower()
+        assert "LEARNER LEVEL" in prompt
+        assert "hablo" in prompt
+        # Anti-stuck rule is suppressed when no_progress_turns < 2.
+        assert "ANTI-STUCK" not in prompt
 
 
 class TestGetConversationSystemPrompt:

--- a/tests/test_services/test_chat_chip_completion.py
+++ b/tests/test_services/test_chat_chip_completion.py
@@ -1,0 +1,88 @@
+"""Pure-Python tests for `check_chat_chip_completion`.
+
+Uses a SimpleNamespace stand-in for the Conversation row so we don't
+need a DB connection. The function only reads `chat_target_forms_json`
+off the conversation, so a duck-typed object is enough.
+
+Run with:
+  python3.11 -m pytest tests/test_services/test_chat_chip_completion.py --noconftest -v
+"""
+from types import SimpleNamespace
+
+from app.services.conversation_service import check_chat_chip_completion
+
+
+def _conv(chips):
+    return SimpleNamespace(chat_target_forms_json=chips)
+
+
+def test_no_chips_returns_empty():
+    complete, ids = check_chat_chip_completion(_conv(None), ["hola"])
+    assert complete is False
+    assert ids == []
+
+
+def test_no_transcripts_returns_empty():
+    chips = [{"id": "x", "spanish": "hablo"}]
+    complete, ids = check_chat_chip_completion(_conv(chips), [])
+    assert complete is False
+    assert ids == []
+
+
+def test_single_chip_ticked():
+    chips = [{"id": "x", "spanish": "hablo", "pronoun": "yo"}]
+    complete, ids = check_chat_chip_completion(
+        _conv(chips), ["yo hablo todos los días"],
+    )
+    assert complete is True
+    assert ids == ["x"]
+
+
+def test_partial_completion_lists_only_ticked():
+    chips = [
+        {"id": "a", "spanish": "hablo", "pronoun": "yo"},
+        {"id": "b", "spanish": "habla", "pronoun": "ella"},
+        {"id": "c", "spanish": "hablan", "pronoun": "ellos"},
+    ]
+    complete, ids = check_chat_chip_completion(
+        _conv(chips),
+        ["yo hablo en casa.", "mi hermana habla mucho"],
+    )
+    assert complete is False
+    assert set(ids) == {"a", "b"}
+
+
+def test_word_boundary_prevents_false_positive():
+    # "hablo" must not match "hablamos" — word-boundary check.
+    chips = [{"id": "yo", "spanish": "hablo", "pronoun": "yo"}]
+    complete, ids = check_chat_chip_completion(
+        _conv(chips), ["nosotros hablamos español"],
+    )
+    assert complete is False
+    assert ids == []
+
+
+def test_accent_insensitive_match():
+    chips = [{"id": "x", "spanish": "tú", "pronoun": "tú"}]
+    complete, ids = check_chat_chip_completion(
+        _conv(chips), ["tu hablas mucho"],
+    )
+    assert complete is True
+    assert ids == ["x"]
+
+
+def test_id_synthesized_when_missing():
+    """Older rows without an `id` field still tick correctly via fallback."""
+    chips = [{"spanish": "hablo", "pronoun": "yo"}]
+    complete, ids = check_chat_chip_completion(_conv(chips), ["yo hablo"])
+    assert complete is True
+    assert ids == ["form:hablo:yo"]
+
+
+def test_punctuation_stripped():
+    chips = [{"id": "x", "spanish": "hablo", "pronoun": "yo"}]
+    complete, ids = check_chat_chip_completion(
+        _conv(chips), ["¡Hablo! ¿Tú?"],
+    )
+    assert complete is True
+    assert ids == ["x"]

--- a/tests/test_services/test_grammar_elicitation.py
+++ b/tests/test_services/test_grammar_elicitation.py
@@ -1,0 +1,77 @@
+"""Pure-Python tests for the Spanish-frame grammar elicitation helper.
+
+Run with: python3.11 -m pytest tests/test_services/test_grammar_elicitation.py --noconftest -v
+"""
+from app.services.grammar_elicitation import (
+    PRONOUN_ELICITATION_FRAMES,
+    format_target_steering,
+)
+from app.services.learner_context import ChipTarget
+
+
+class TestFrames:
+    def test_all_pronouns_covered(self):
+        expected = {
+            "yo", "tú", "él", "ella", "usted",
+            "nosotros", "nosotras", "ellos", "ellas", "ustedes",
+        }
+        assert set(PRONOUN_ELICITATION_FRAMES.keys()) == expected
+
+    def test_frames_are_spanish(self):
+        """Frames lead with Spanish copy, not English."""
+        for pronoun, frame in PRONOUN_ELICITATION_FRAMES.items():
+            # Each frame contains a Spanish question or sentence-stem;
+            # English appears only inside the [bare_lemma in X form] slot.
+            stripped = frame.split("[")[0].strip()
+            # Spanish anchors: "Yo", "Cuéntame", "Y tu", "Tus", etc.
+            assert any(stripped.startswith(p) for p in (
+                "Yo", "Cuéntame", "Y", "Tus",
+            )), f"{pronoun} frame doesn't start with Spanish copy: {frame!r}"
+
+
+class TestFormatTargetSteering:
+    def test_empty_chips_returns_empty_string(self):
+        assert format_target_steering([], []) == ""
+
+    def test_all_completed_returns_empty_string(self):
+        chips = [ChipTarget(id="x", spanish="hola", english="hi")]
+        assert format_target_steering(chips, ["x"]) == ""
+
+    def test_pending_only(self):
+        chips = [
+            ChipTarget(id="a", spanish="agua", english="water"),
+            ChipTarget(id="b", spanish="pan", english="bread"),
+        ]
+        out = format_target_steering(chips, ["a"])
+        assert "agua" not in out
+        assert "pan" in out
+
+    def test_grammar_chip_has_elicitation_frame(self):
+        chip = ChipTarget(
+            id="conj_hablar_yo",
+            spanish="hablo",
+            english="I speak",
+            verb="hablar",
+            pronoun="yo",
+        )
+        out = format_target_steering([chip], [])
+        assert "hablo" in out
+        assert "Elicit with:" in out
+        # Frame should reference the target form for "yo"
+        assert "1st person" in out
+
+    def test_vocab_chip_has_no_elicitation_frame(self):
+        chip = ChipTarget(id="word_botella", spanish="botella", english="bottle")
+        out = format_target_steering([chip], [])
+        assert "botella" in out
+        assert "Elicit with:" not in out
+
+    def test_unknown_pronoun_falls_back_to_generic_frame(self):
+        chip = ChipTarget(
+            id="x", spanish="forma", english="form",
+            verb="hablar", pronoun="vos",  # not in PRONOUN_ELICITATION_FRAMES
+        )
+        out = format_target_steering([chip], [])
+        assert "forma" in out
+        # Generic fallback uses the bare lemma + pronoun template.
+        assert "speak" in out.lower() or "vos" in out

--- a/tests/test_services/test_learner_level.py
+++ b/tests/test_services/test_learner_level.py
@@ -1,0 +1,58 @@
+"""Pure-Python tests for the level-aware prompt rule helpers.
+
+Run with: python3.11 -m pytest tests/test_services/test_learner_level.py --noconftest -v
+"""
+from app.services.learner_level import (
+    level_rules_for_conversation,
+    level_rules_for_hint,
+)
+
+
+class TestLevelRulesForHint:
+    def test_each_level_returns_distinct_string(self):
+        seen = {
+            level_rules_for_hint(level)
+            for level in ("a", "b", "c", "d")
+        }
+        assert len(seen) == 4
+
+    def test_null_falls_back_to_intermediate(self):
+        assert level_rules_for_hint(None) == level_rules_for_hint("c")
+        assert level_rules_for_hint("") == level_rules_for_hint("c")
+
+    def test_unknown_level_falls_back_to_intermediate(self):
+        assert level_rules_for_hint("zzz") == level_rules_for_hint("c")
+
+    def test_a_is_strictest(self):
+        a = level_rules_for_hint("a")
+        d = level_rules_for_hint("d")
+        assert "5–7 words" in a
+        assert "14 words" in d
+
+
+class TestLevelRulesForConversation:
+    def test_each_level_returns_distinct_string(self):
+        seen = {
+            level_rules_for_conversation(level)
+            for level in ("a", "b", "c", "d")
+        }
+        assert len(seen) == 4
+
+    def test_null_falls_back_to_intermediate(self):
+        assert level_rules_for_conversation(None) == level_rules_for_conversation("c")
+
+    def test_a_is_slowest(self):
+        a = level_rules_for_conversation("a")
+        assert "Speak slowly" in a
+        assert "4–6 word sentences" in a
+
+    def test_d_is_natural(self):
+        d = level_rules_for_conversation("d")
+        assert "normally" in d.lower()
+
+
+class TestSeparateRules:
+    def test_hint_and_conversation_diverge(self):
+        """Hint rule talks about a single sentence; conversation rule about cadence."""
+        for level in ("a", "b", "c", "d"):
+            assert level_rules_for_hint(level) != level_rules_for_conversation(level)


### PR DESCRIPTION
…stuck

The avatar now adapts to the learner's q0_spanish_level (a/b/c/d), reads the FE's chip panel directly, and escalates scaffolding when the learner skips the target multiple turns in a row.

- Add v3 conversation_agent / grammar_agent templates with goal, level rule, target steering, and anti-stuck sections (prompts.json).
- New shared `learner_level.level_rules_for_{conversation,hint}`, consumed by both the system prompt and `sentence_hint_service`.
- New `learner_context.LearnerContext` carrier piped through `voice_turn_service.build_system_prompt` and the realtime config.
- Replace 370+ lines of English-hardcoded `_build_grammar_hint` with `grammar_elicitation.PRONOUN_ELICITATION_FRAMES` (Spanish per-pronoun templates injected straight into the system prompt).
- Persist `chat_target_forms_json` + `completed_chip_ids` per conversation; `check_chat_chip_completion` gates completion on the same chips the FE shows. Vocab encounters keep the legacy infinitive path. Migration 027 adds the new columns.
- `persist_turn` resets/increments `consecutive_no_progress_turns` and unions newly-ticked chip ids; v3 anti-stuck rule fires at >= 2.
- VoiceTurn / RealtimeTurn responses expose `completed_chip_ids` and `consecutive_no_progress_turns` so the FE can drop client-side chip matching and surface a "Need help?" nudge.
- `select_words_for_situation` becomes mastery-aware: HF picks within [VL-50, VL+100], with `q0_spanish_level` cold-start floor.
- Sentence-hint prompt gains 2 grammar few-shots so suggestions stop reaching for infinitives when chips are conjugated forms.
- Tests: new pure-Python suites for learner_level, grammar_elicitation, and check_chat_chip_completion; test_prompts.py updated to v3.