### PR TITLE
Fix migration 027 revision id length (alembic_version VARCHAR(32))

### DIFF
--- a/migrations/versions/027_avatar_dynamics_progress_tracking.py
+++ b/migrations/versions/027_avatar_dynamics_progress_tracking.py
@@ -1,6 +1,6 @@
 """Track per-conversation stuck state and chip targets for grammar chats.
 
-Revision ID: 027_avatar_dynamics_progress_tracking
+Revision ID: 027_avatar_dynamics
 Revises: 026_sentence_hints
 Create Date: 2026-05-02
 
@@ -24,7 +24,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 
 
-revision = "027_avatar_dynamics_progress_tracking"
+revision = "027_avatar_dynamics"
 down_revision = "026_sentence_hints"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- Migration `027_avatar_dynamics_progress_tracking.py` declared `revision = \"027_avatar_dynamics_progress_tracking\"` (37 chars), exceeding the default `alembic_version.version_num VARCHAR(32)` column.
- On Railway QA, `alembic upgrade head` failed with `psycopg2.errors.StringDataRightTruncation` while writing the new head, blocking startup (`start.py` exits non-zero).
- Renamed the revision id to `027_avatar_dynamics` (19 chars). The migration body is unchanged. No other files reference the old id; the file name is left as-is (alembic keys off the in-file `revision`, not the filename).

Because alembic runs the upgrade in a transaction with DDL, the failed step rolled back fully — QA is still at `026_sentence_hints`, no manual cleanup needed before redeploying.

## Test plan
- [ ] Redeploy QA from this branch and confirm `alembic upgrade head` advances to `027_avatar_dynamics` without error
- [ ] Confirm `conversations.consecutive_no_progress_turns` and `conversations.chat_target_forms_json` are present after migration
- [ ] Smoke test a grammar chat encounter to verify the avatar-dynamics features still work