### PR TITLE
Merge alembic heads: avatar dead-end + grammar consolidation

### DIFF
--- a/migrations/versions/029_merge_028s.py
+++ b/migrations/versions/029_merge_028s.py
@@ -2,7 +2,7 @@
 
 Revision ID: 029_merge_028s
 Revises: 028_avatar_dead_end, 028_drop_merged_lessons
-Create Date: 2026-05-02
+Create Date: 2026-05-03
 
 Two parallel branches forked from `026_sentence_hints`:
 

--- a/migrations/versions/029_merge_028s.py
+++ b/migrations/versions/029_merge_028s.py
@@ -1,0 +1,32 @@
+"""Merge avatar dead-end and grammar consolidation chains.
+
+Revision ID: 029_merge_028s
+Revises: 028_avatar_dead_end, 028_drop_merged_lessons
+Create Date: 2026-05-02
+
+Two parallel branches forked from `026_sentence_hints`:
+
+- avatar dynamics chain: `027_avatar_dynamics` → `028_avatar_dead_end`
+- grammar consolidation chain: `027_drop_poss_adj_plural` → `028_drop_merged_lessons`
+
+Both landed on the `qa` branch around the same time, leaving alembic
+with two heads and `alembic upgrade head` failing with "Multiple
+head revisions are present". This migration has no schema changes —
+it only joins the two chains so alembic has a single head again.
+"""
+from alembic import op  # noqa: F401  (kept for parity with sibling migrations)
+import sqlalchemy as sa  # noqa: F401
+
+
+revision = "029_merge_028s"
+down_revision = ("028_avatar_dead_end", "028_drop_merged_lessons")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Why

QA deploys are failing with:
\`\`\`
ERROR [alembic.util.messaging] Multiple head revisions are present for given argument 'head'
FAILED: Multiple head revisions are present for given argument 'head'
\`\`\`

Two parallel migration branches forked from \`026_sentence_hints\` landed on \`qa\` around the same time and never got merged:

\`\`\`
                    ┌── 027_avatar_dynamics ── 028_avatar_dead_end          (head A)
026_sentence_hints ─┤
                    └── 027_drop_poss_adj_plural ── 028_drop_merged_lessons (head B)
\`\`\`

Alembic refuses to advance when there's no single head, so every redeploy crashes at startup.

## Fix

Add an empty merge migration whose \`down_revision\` is the tuple \`(\"028_avatar_dead_end\", \"028_drop_merged_lessons\")\`. No schema changes — both branches' schema migrations already ran cleanly; this just joins the chain so alembic has a single head again.

\`\`\`python
revision = \"029_merge_028s\"
down_revision = (\"028_avatar_dead_end\", \"028_drop_merged_lessons\")
\`\`\`

Verified locally:
- \`alembic heads\` now returns a single head: \`029_merge_028s (head)\`
- \`alembic history\` shows the mergepoint and both parent chains
- Revision id is 14 chars, well within \`alembic_version VARCHAR(32)\`

## Test plan
- [ ] Redeploy QA — \`alembic upgrade head\` should advance through both branches and finish at \`029_merge_028s\` without error
- [ ] Confirm both columns added by the parent migrations are present in the QA database (\`avatar_dead_end_turns\` from 028_avatar_dead_end, schema/data changes from 028_drop_merged_lessons)