### PR TITLE
Fix grammar consolidation migrations: nullify milestone FK first

### DIFF
--- a/migrations/versions/027_drop_possessive_adj_plural.py
+++ b/migrations/versions/027_drop_possessive_adj_plural.py
@@ -29,6 +29,15 @@ DEAD_SID = "grammar_possessive_adj_plural"
 
 
 def upgrade() -> None:
+    # `user_milestone_events.conversation_id` FKs to conversations.id with no
+    # ON DELETE clause, so deleting a referenced conversation row aborts the
+    # transaction. Nullify the link first — the milestone (e.g. first_word)
+    # remains, we just lose the pointer to which conversation it happened in.
+    op.execute(
+        f"UPDATE user_milestone_events SET conversation_id = NULL "
+        f"WHERE conversation_id IN ("
+        f"SELECT id FROM conversations WHERE situation_id = '{DEAD_SID}')"
+    )
     # NOT NULL situation_id → delete row.
     op.execute(f"DELETE FROM conversations WHERE situation_id = '{DEAD_SID}'")
     op.execute(f"DELETE FROM daily_encounter_logs WHERE situation_id = '{DEAD_SID}'")

--- a/migrations/versions/028_drop_merged_lessons.py
+++ b/migrations/versions/028_drop_merged_lessons.py
@@ -70,6 +70,15 @@ DEAD_SIDS = [
 
 def upgrade() -> None:
     sids_csv = ", ".join(f"'{s}'" for s in DEAD_SIDS)
+    # `user_milestone_events.conversation_id` FKs to conversations.id with no
+    # ON DELETE clause, so deleting a referenced conversation row aborts the
+    # transaction. Nullify the link first — see sibling migration 027 for
+    # context.
+    op.execute(
+        f"UPDATE user_milestone_events SET conversation_id = NULL "
+        f"WHERE conversation_id IN ("
+        f"SELECT id FROM conversations WHERE situation_id IN ({sids_csv}))"
+    )
     # NOT NULL situation_id → delete the row
     op.execute(f"DELETE FROM conversations WHERE situation_id IN ({sids_csv})")
     op.execute(f"DELETE FROM daily_encounter_logs WHERE situation_id IN ({sids_csv})")


### PR DESCRIPTION
Migrations 027_drop_poss_adj_plural and 028_drop_merged_lessons both DELETE FROM conversations for the situations being removed. But `user_milestone_events.conversation_id` references conversations.id with no ON DELETE clause, so any milestone row pointing at a doomed conversation aborts the migration with:

  ForeignKeyViolation: update or delete on table "conversations"
  violates foreign key constraint "user_milestone_events_conversation_id_fkey"

QA was hitting this on the very first DELETE. Both migrations now NULL out `user_milestone_events.conversation_id` for the affected conversations before deleting them — the milestone (e.g. first_word) remains, only the back-pointer to the conversation is dropped.

Edited in place because the migrations are blocking and have not been applied to any DB yet (QA was failing at this exact step).