### PR TITLE
Learner experience: disambiguate chips, article hints, anti-stuck menu

### DIFF
--- a/app/data/seed_bank.py
+++ b/app/data/seed_bank.py
@@ -51,7 +51,7 @@ _SUB_SITUATIONS = {
                 ("embarque", "boarding", "embarcament", "ombordstigning"), ("hora de embarque", "boarding time", "hora d'embarcament", "ombordstigningstid"), ("hora de salida", "departure time", "hora de sortida", "avgångstid"),  # Encounter 12
                 ("puerta", "gate", "porta", "dörr"), ("número de puerta", "gate number", "número de porta", "gate-nummer"), ("puerta de embarque", "boarding gate", "porta d’embarcament", "gate"),  # Encounter 13
                 ("zona de embarque", "boarding area", "zona d'embarcament", "incheckningsområde"), ("preembarque", "preboarding", "preembarqui", "förboarding"), ("prioridad", "priority", "prioritat", "prioritet"),  # Encounter 14
-                ("a tiempo", "on time", "a temps", "i tid"), ("retraso", "delay", "retard", "försening"), ("demora", "delay", "retard", "försening"),  # Encounter 15
+                ("a tiempo", "on time", "a temps", "i tid"), ("retraso", "delay", "retard", "försening"), ("demora", "delay (alt.)", "retard", "försening"),  # Encounter 15
                 ("cambio de puerta", "gate change", "canvi de porta", "gatebyte"), ("¿cuál es la puerta?", "what is the gate?", "quina és la porta?", "vilken är gaten?"), ("aparece en las pantallas", "it appears on the screens", "apareix a les pantalles", "det visas på skärmarna"),  # Encounter 16
                 ("aparece en la app", "it appears in the app", "apareix a l'app", "det visas i appen"), ("no está asignada", "it is not assigned", "no està assignada", "den är inte tilldelad"), ("asiento", "seat", "seient", "säte"),  # Encounter 17
                 ("número de asiento", "seat number", "número de seient", "platsnummer"), ("fila", "row", "cua", "rad"), ("ventana", "window", "finestra", "fönster"),  # Encounter 18
@@ -100,7 +100,7 @@ _SUB_SITUATIONS = {
                 ("cuenta", "account", "compte", "konto"), ("cuenta bancaria", "bank account", "compte bancari", "bankkonto"), ("saldo", "balance", "saldo", "saldo"),  # Encounter 2
                 ("saldo disponible", "available balance", "saldo disponible", "tillgängligt saldo"), ("saldo actual", "current balance", "saldo actual", "aktuellt saldo"), ("tarjeta", "card", "targeta", "kort"),  # Encounter 3
                 ("tarjeta de débito", "debit card", "targeta de dèbit", "betalkort"), ("tarjeta de crédito", "credit card", "targeta de crèdit", "kreditkort"), ("tarjeta bloqueada", "blocked card", "targeta bloquejada", "blockerat kort"),  # Encounter 4
-                ("tarjeta nueva", "new card", "targeta nova", "nytt kort"), ("PIN", "PIN", "PIN", "PIN"), ("clave", "PIN", "clau", ""),  # Encounter 5
+                ("tarjeta nueva", "new card", "targeta nova", "nytt kort"), ("PIN", "PIN", "PIN", "PIN"), ("clave", "PIN/code", "clau", ""),  # Encounter 5
                 ("contraseña", "password", "contrasenya", "lösenord"), ("número de cuenta", "account number", "número de compte", "kontonummer"), ("número incorrecto", "wrong number", "número incorrecte", "fel nummer"),  # Encounter 6
                 ("transferencia", "transfer", "transferència", "överföring"), ("transferencia enviada", "sent transfer", "transferència enviada", "skickad överföring"), ("transferencia recibida", "received transfer", "transferència rebuda", "mottagen överföring"),  # Encounter 7
                 ("no llegó", "it did not arrive", "no va arribar", "det kom inte"), ("llegó tarde", "it arrived late", "va arribar tard", "den kom för sent"), ("comprobante", "receipt", "justificant", "kvitto"),  # Encounter 8
@@ -111,7 +111,7 @@ _SUB_SITUATIONS = {
                 ("activan la tarjeta", "they activate the card", "activen la targeta", "de aktiverar kortet"), ("emiten la tarjeta", "they issue the card", "emeten la targeta", "de utfärdar kortet"), ("funciona ahora", "it works now", "funciona ara", "det fungerar nu"),  # Encounter 13
                 ("no funciona", "it does not work", "no funciona", "det fungerar inte"), ("rechazada", "declined", "rebutjada", "avvisad"), ("pago rechazado", "declined payment", "pagament rebutjat", "avvisad betalning"),  # Encounter 14
                 ("hago el pago", "I make the payment", "faig el pagament", "jag gör betalningen"), ("pago aprobado", "approved payment", "pagament aprovat", "godkänd betalning"), ("pago pendiente", "pending payment", "pagament pendent", "obetalad betalning"),  # Encounter 15
-                ("monto", "amount", "import", "belopp"), ("monto total", "total amount", "import total", "totalt belopp"), ("cantidad", "amount", "quantitat", "mängd"),  # Encounter 16
+                ("monto", "amount", "import", "belopp"), ("monto total", "total amount", "import total", "totalt belopp"), ("cantidad", "quantity", "quantitat", "mängd"),  # Encounter 16
                 ("deposito dinero", "I deposit money", "diposito diners", "jag sätter in pengar"), ("retiro", "withdrawal", "retirada", "uttag"), ("retiro dinero", "I withdraw money", "retiro diners", "jag tar ut pengar"),  # Encounter 17
                 ("efectivo", "cash", "efectiu", "kontanter"), ("con tarjeta", "with a card", "amb targeta", "med kort"), ("cajero automático", "ATM", "caixer automàtic", "bankomat"),  # Encounter 18
                 ("retiro en el cajero", "I withdraw at the ATM", "retiro a l'caixer", "jag tar ut pengar i bankomaten"), ("saldo insuficiente", "insufficient funds", "saldo insuficient", "otillräckligt saldo"), ("no hay fondos", "there are no funds", "no hi ha fons", "det finns inga medel"),  # Encounter 19
@@ -221,7 +221,7 @@ _SUB_SITUATIONS = {
                 ("total", "total", "total", "totalt"), ("pago", "payment", "pagament", "betalning"), ("anticipo", "deposit", "avançament", "förskottsbetalning"),  # Encounter 5
                 ("pago final", "final payment", "pagament final", "slutbetalning"), ("material", "material", "material", "material"), ("materiales", "materials", "materials", "material"),  # Encounter 6
                 ("proveedor", "supplier", "proveïdor", "leverantör"), ("disponibilidad", "availability", "disponibilitat", "tillgänglighet"), ("no está disponible", "it is not available", "no està disponible", "det är inte tillgängligt"),  # Encounter 7
-                ("retraso", "delay", "retard", "försening"), ("atraso", "delay", "retard", "försening"), ("va atrasado", "it is running late", "va amb retard", "den är försenad"),  # Encounter 8
+                ("retraso", "delay", "retard", "försening"), ("atraso", "delay (alt.)", "retard", "försening"), ("va atrasado", "it is running late", "va amb retard", "den är försenad"),  # Encounter 8
                 ("a tiempo", "on time", "a temps", "i tid"), ("horario", "schedule", "horari", "öppettider"), ("cumplen el horario", "they keep the schedule", "compleixen l’horari", "de håller schemat"),  # Encounter 9
                 ("tiempo estimado", "estimated time", "temps estimat", "beräknad tid"), ("terminan hoy", "they finish today", "acaben avui", "de slutar idag"), ("empiezan hoy", "they start today", "comencen avui", "de börjar idag"),  # Encounter 10
                 ("siguen trabajando", "they keep working", "segueixen treballant", "de fortsätter arbeta"), ("trabajo detenido", "stopped work", "feina aturada", "stoppat arbete"), ("revisan esto", "they check this", "revisen això", "de kontrollerar detta"),  # Encounter 11
@@ -450,13 +450,13 @@ _SUB_SITUATIONS = {
             "goal": "Order food, interact with the server, and pay for your meal",
             "word_prefix": "rest",
             "words": [
-                ("menú", "menu", "menú", "meny"), ("carta", "menu", "carta", ""), ("mesero", "waiter", "cambrer", "servitör"),  # Encounter 1
+                ("menú", "menu", "menú", "meny"), ("carta", "menu (à la carte)", "carta", ""), ("mesero", "waiter", "cambrer", "servitör"),  # Encounter 1
                 ("mesa", "table", "taula", "bord"), ("reserva", "reservation", "reserva", "bokning"), ("¿tienen reserva?", "do you have a reservation?", "tenen reserva?", "har ni en bokning?"),  # Encounter 2
                 ("mesa para dos", "table for two", "taula per a dos", "bord för två"), ("pido", "I order", "demano", "jag beställer"), ("¿qué desea?", "what would you like?", "què desitja?", "vad önskar du?"),  # Encounter 3
                 ("¿qué van a pedir?", "what are you going to order?", "què demanareu?", "vad ska ni beställa?"), ("tomo la orden", "I take the order", "prenc la comanda", "jag tar beställningen"), ("aquí está el menú", "here is the menu", "aquí teniu el menú", "här är menyn"),  # Encounter 4
                 ("recomendación", "recommendation", "recomanació", "rekommendation"), ("¿qué recomienda?", "what do you recommend?", "què recomana?", "vad rekommenderar du?"), ("plato", "dish", "plat", "rätt"),  # Encounter 5
                 ("entrada", "appetizer", "entrada", "ingång"), ("plato principal", "main dish", "plat principal", "huvudrätt"), ("postre", "dessert", "postres", "efterrätt"),  # Encounter 6
-                ("acompañamiento", "side dish", "acompanyament", "tillbehör"), ("guarnición", "side dish", "guarnició", "sidorätt"), ("porción", "portion", "porció", "portion"),  # Encounter 7
+                ("acompañamiento", "side dish", "acompanyament", "tillbehör"), ("guarnición", "garnish", "guarnició", "sidorätt"), ("porción", "portion", "porció", "portion"),  # Encounter 7
                 ("ingrediente", "ingredient", "ingredient", "ingrediens"), ("salsa", "sauce", "salsa", "sås"), ("arroz", "rice", "arròs", "ris"),  # Encounter 8
                 ("pollo", "chicken", "pollastre", "kyckling"), ("carne", "meat", "carn", "kött"), ("pescado", "fish", "peix", "fisk"),  # Encounter 9
                 ("verduras", "vegetables", "verdures", "grönsaker"), ("ensalada", "salad", "amanida", "sallad"), ("vegetariano", "vegetarian", "vegetarià", "vegetarian"),  # Encounter 10

--- a/app/services/grammar_elicitation.py
+++ b/app/services/grammar_elicitation.py
@@ -106,6 +106,40 @@ VOCAB_ELICITATION_HINTS: tuple[tuple[str, str], ...] = (
         "'¿A qué lugar se dirige?' → 'al…'). "
         "Do NOT say `al` yourself.",
     ),
+    # Order: more-specific plural patterns before bare gender patterns,
+    # so a chip labelled `the (masc. pl.)` matches the plural rule first.
+    (
+        "(masc. pl.)",
+        "ask a content question whose natural answer is a noun phrase "
+        "starting with the masc.-plural article + noun "
+        "(e.g. '¿Dónde están los pasajeros?' → 'los pasajeros están…'; "
+        "'¿Cuántos asientos hay?' → 'hay unos asientos libres'). "
+        "The answer must include a masc. plural noun.",
+    ),
+    (
+        "(fem. pl.)",
+        "ask a content question whose natural answer is a noun phrase "
+        "starting with the fem.-plural article + noun "
+        "(e.g. '¿A qué horas salen los vuelos?' → 'a las 8…'; "
+        "'¿Cuáles son las puertas disponibles?' → 'las puertas son…'). "
+        "The answer must include a fem. plural noun.",
+    ),
+    (
+        "(masc.)",
+        "ask a content question whose natural answer is a noun phrase "
+        "starting with the masc.-singular article + noun "
+        "(e.g. '¿Cuál es el problema?' → 'el problema es…'; "
+        "'¿Tiene equipaje?' → 'tengo un maletín'). "
+        "The answer must include a masc. singular noun.",
+    ),
+    (
+        "(fem.)",
+        "ask a content question whose natural answer is a noun phrase "
+        "starting with the fem.-singular article + noun "
+        "(e.g. '¿Cuál es la fecha?' → 'la fecha es…'; "
+        "'¿Tiene reserva?' → 'tengo una reserva'). "
+        "The answer must include a fem. singular noun.",
+    ),
 )
 
 

--- a/app/services/voice_turn_service.py
+++ b/app/services/voice_turn_service.py
@@ -45,7 +45,11 @@ def is_advanced_mode(language_mode: str) -> bool:
     )
 
 
-_STUCK_THRESHOLD_NUDGE = 2
+# Threshold for the tactics menu. Fires after a single consecutive
+# no-progress turn so a native-English learner gets explicit scaffolding
+# early rather than after 2 unhelpful turns. The translate-tactic
+# (last-resort English parenthetical) still requires 3 stuck turns.
+_STUCK_THRESHOLD_NUDGE = 1
 _STUCK_THRESHOLD_TRANSLATE = 3
 
 
@@ -57,27 +61,45 @@ def _render_goal_block(goal: Optional[str]) -> str:
 
 def _render_anti_stuck_rule(consecutive_no_progress_turns: int) -> str:
     """Inject a stronger scaffolding directive once the learner has skipped
-    the target multiple turns in a row.
+    the target one or more turns in a row.
 
     Below the nudge threshold the section is empty so the prompt isn't
-    polluted on the first turn of every conversation. Above the
-    translate threshold we authorise the AI to gloss the target form in
-    English parentheses — a last resort that keeps the lesson moving.
+    polluted on the very first turn. At the nudge level we surface a
+    menu of alternative elicitation tactics (synonym / define / contrast
+    / fill-in-blank / embedded yes/no) so the LLM has options instead
+    of repeating its instinct verbatim. Above the translate threshold
+    we authorise English glossing of the form as a last resort.
+
+    Why a menu: from the avatar-dynamics screenshots we saw the LLM
+    looping on the same elicitation pattern ("¿Cuál es el vuelo?")
+    when the student didn't progress, exhausting the learner. A menu
+    forces tactic rotation.
     """
     n = consecutive_no_progress_turns or 0
     if n < _STUCK_THRESHOLD_NUDGE:
         return ""
     if n < _STUCK_THRESHOLD_TRANSLATE:
         return (
-            f"ANTI-STUCK: the student has skipped the target {n} turns in a row. "
-            "Drop one level of indirectness — ask a fill-in-style question or a "
-            "yes/no with the target form embedded ('¿Tú cantas o no cantas?')."
+            f"ANTI-STUCK: the student skipped the target {n} turn(s) in a row. "
+            "Switch tactic this turn — pick ONE you haven't used in the last "
+            "2 turns:\n"
+            "- Synonym: use a near-synonym, ask the student to rephrase "
+            "('Yo diría que va demorado — ¿tú cómo lo describirías?').\n"
+            "- Define: describe the meaning, ask the student to name it "
+            "('Cuando un vuelo no sale a tiempo, ¿cómo le decimos?').\n"
+            "- Contrast: state your own side, ask the student's "
+            "('Mi vuelo está a tiempo — ¿y el suyo?').\n"
+            "- Fill-in-blank: leave a blank, ask the student to complete "
+            "('Su vuelo va con un ___ de dos horas, ¿correcto?').\n"
+            "- Embedded yes/no (last resort): include the form in a yes/no "
+            "so the student echoes it ('¿Su vuelo está retrasado?'); only "
+            "if the others already failed."
         )
     return (
-        f"ANTI-STUCK: the student has skipped the target {n} turns in a row. "
-        "Drop indirectness completely — translate the target form into English "
-        "in parentheses inside your question, e.g. '¿Tú cantas (do you sing) "
-        "en la ducha?'."
+        f"ANTI-STUCK: the student skipped the target {n} turns in a row. "
+        "Drop indirectness completely — translate the target form into "
+        "English in parentheses inside your question, e.g. '¿Tú cantas "
+        "(do you sing) en la ducha?'."
     )
 
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -228,7 +228,8 @@ class TestBuildSystemPrompt:
         assert "Speak in Spanish" in prompt
         assert "LEARNER LEVEL" in prompt
         assert "hablo" in prompt
-        # Anti-stuck rule is suppressed when no_progress_turns < 2.
+        # Anti-stuck rule is suppressed when no_progress_turns == 0;
+        # the dedicated rendering tests live in test_anti_stuck_rule.py.
         assert "ANTI-STUCK" not in prompt
 
 

--- a/tests/test_seed_data.py
+++ b/tests/test_seed_data.py
@@ -119,6 +119,38 @@ class TestEncounterWords:
         assert not duplicates, f"Duplicate word IDs: {duplicates}"
 
 
+class TestNoDuplicateEnglishLabelsPerEncounter:
+    """Encounters with two chips that share an English label render as
+    visually identical chips on the FE — the learner can't tell which
+    one is ticked. Audited and disambiguated in PR #32-followup; this
+    test locks the audit in.
+
+    If you're adding a near-synonym pair on purpose (e.g. retraso /
+    demora), disambiguate the labels at seed time — `delay (alt.)`,
+    `menu (à la carte)`, `garnish`, etc. — rather than reusing the
+    canonical English form.
+    """
+
+    def test_no_duplicate_english_within_encounter(self):
+        for category, sub_list in _SUB_SITUATIONS.items():
+            for sub in sub_list:
+                words = sub["words"]
+                # Encounters are groups of 3 consecutive (sp, en, ca, sv) tuples
+                for i in range(0, len(words), 3):
+                    chunk = words[i:i + 3]
+                    english = [t[1] for t in chunk]
+                    duplicates = [
+                        en for en, count in Counter(english).items()
+                        if count > 1
+                    ]
+                    enc_num = i // 3 + 1
+                    assert not duplicates, (
+                        f"{category}/{sub['title']} encounter {enc_num}: "
+                        f"duplicate English label(s) {duplicates}. "
+                        "Disambiguate one (e.g. add `(alt.)`)."
+                    )
+
+
 class TestNoDuplicateSpanishWords:
     def test_no_duplicate_spanish_within_sub_situation(self):
         for category, sub_list in _SUB_SITUATIONS.items():

--- a/tests/test_services/test_anti_stuck_rule.py
+++ b/tests/test_services/test_anti_stuck_rule.py
@@ -1,0 +1,86 @@
+"""Tests for the ANTI-STUCK rule renderer.
+
+Run: python3.11 -m pytest tests/test_services/test_anti_stuck_rule.py --noconftest -v
+
+The renderer escalates scaffolding as the learner skips the target
+chip across consecutive turns. Three behaviours to lock in:
+
+1. n=0 returns an empty string — no scaffolding pollution on the very
+   first turn of every conversation.
+2. 1 ≤ n < TRANSLATE returns the tactics menu (synonym / define /
+   contrast / fill-in-blank / embedded yes/no) so the LLM rotates
+   strategies instead of repeating one elicitation pattern.
+3. n ≥ TRANSLATE returns the last-resort English-parenthetical
+   instruction.
+
+Lowering the nudge threshold from 2 → 1 was a behavioural choice for
+native-English-speaking learners; locking it in here so a future
+"performance" tweak doesn't silently push it back without test churn.
+"""
+from __future__ import annotations
+
+from app.services.voice_turn_service import (
+    _render_anti_stuck_rule,
+    _STUCK_THRESHOLD_NUDGE,
+    _STUCK_THRESHOLD_TRANSLATE,
+)
+
+
+class TestThresholds:
+    def test_nudge_fires_after_one_no_progress_turn(self):
+        """Native-English learners need scaffolding fast. Nudge starts at n=1."""
+        assert _STUCK_THRESHOLD_NUDGE == 1
+
+    def test_translate_threshold_unchanged(self):
+        """Last-resort English glossing still requires 3 stuck turns."""
+        assert _STUCK_THRESHOLD_TRANSLATE == 3
+
+
+class TestRenderedText:
+    def test_zero_returns_empty(self):
+        assert _render_anti_stuck_rule(0) == ""
+
+    def test_negative_treated_as_zero(self):
+        assert _render_anti_stuck_rule(-1) == ""
+
+    def test_none_treated_as_zero(self):
+        # The renderer accepts the legacy None coming out of older
+        # learner_ctx call-sites (defaults to 0).
+        assert _render_anti_stuck_rule(None) == ""  # type: ignore[arg-type]
+
+    def test_nudge_level_lists_all_five_tactics(self):
+        """The menu must surface every alternative tactic so the LLM
+        actually rotates instead of looping on one pattern."""
+        out = _render_anti_stuck_rule(1)
+        assert "ANTI-STUCK" in out
+        for tactic in ("Synonym", "Define", "Contrast",
+                       "Fill-in-blank", "Embedded yes/no"):
+            assert tactic in out, f"tactic {tactic!r} missing from menu"
+
+    def test_nudge_level_uses_spanish_examples(self):
+        """Examples should be in the target language, not English —
+        the LLM tends to mirror the language of its examples."""
+        out = _render_anti_stuck_rule(1)
+        # Sample Spanish anchor phrases from the menu's examples.
+        for sample in ("demorado", "no sale a tiempo", "está a tiempo"):
+            assert sample in out, f"Spanish example {sample!r} missing"
+
+    def test_translate_level_kicks_in_at_threshold(self):
+        out = _render_anti_stuck_rule(_STUCK_THRESHOLD_TRANSLATE)
+        assert "translate" in out.lower()
+        # The menu tactics should NOT also appear at translate level —
+        # we want the prompt to commit to one behaviour, not show both.
+        assert "Synonym" not in out
+        assert "Embedded yes/no" not in out
+
+    def test_intermediate_levels_still_show_menu(self):
+        """n=1 and n=2 both show the menu (translate threshold = 3)."""
+        out_1 = _render_anti_stuck_rule(1)
+        out_2 = _render_anti_stuck_rule(2)
+        assert "Synonym" in out_1 and "Synonym" in out_2
+
+    def test_count_appears_in_message(self):
+        """The count is interpolated so the LLM knows how stuck the
+        learner has been (helps it pick a more direct tactic)."""
+        out_2 = _render_anti_stuck_rule(2)
+        assert "2 turn" in out_2

--- a/tests/test_services/test_grammar_elicitation.py
+++ b/tests/test_services/test_grammar_elicitation.py
@@ -183,3 +183,43 @@ class TestVocabElicitationHints:
             id="hf_2014", spanish="quedarte", english="to stay (reflexive)",
         )
         assert _vocab_elicitation_hint(chip) is not None
+
+    def test_masc_singular_article_emits_hint(self):
+        """`the (masc.)` and `a/an (masc.)` get masc.-singular hint."""
+        for spanish, english in (("el", "the (masc.)"), ("un", "a/an (masc.)")):
+            chip = ChipTarget(id="x", spanish=spanish, english=english)
+            out = format_target_steering([chip], [])
+            assert "Elicit with:" in out, f"missing hint for {english!r}"
+            assert "masc." in out or "masculine" in out.lower()
+            assert "singular" in out.lower()
+
+    def test_fem_singular_article_emits_hint(self):
+        for spanish, english in (("la", "the (fem.)"), ("una", "a/an (fem.)")):
+            chip = ChipTarget(id="x", spanish=spanish, english=english)
+            out = format_target_steering([chip], [])
+            assert "Elicit with:" in out, f"missing hint for {english!r}"
+            assert "fem." in out
+            assert "singular" in out.lower()
+
+    def test_masc_plural_article_emits_hint(self):
+        chip = ChipTarget(id="x", spanish="los", english="the (masc. pl.)")
+        out = format_target_steering([chip], [])
+        assert "Elicit with:" in out
+        assert "masc." in out
+        assert "plural" in out.lower()
+
+    def test_fem_plural_article_emits_hint(self):
+        chip = ChipTarget(id="x", spanish="las", english="the (fem. pl.)")
+        out = format_target_steering([chip], [])
+        assert "Elicit with:" in out
+        assert "fem." in out
+        assert "plural" in out.lower()
+
+    def test_plural_pattern_does_not_collide_with_singular(self):
+        """Pattern order must not let `(masc.)` match a `(masc. pl.)`
+        chip. Confirms the singular hint is absent from a plural chip."""
+        chip = ChipTarget(id="x", spanish="los", english="the (masc. pl.)")
+        out = format_target_steering([chip], [])
+        # The plural-only example should appear; the singular-only one shouldn't.
+        assert "pasajeros" in out or "asientos" in out
+        assert "el problema" not in out


### PR DESCRIPTION
## Summary

Three improvements aimed at native-English learners of Spanish, driven by the airport-encounter screenshots from the avatar-dynamics thread (chip panel showing two identical \`delay\` chips, abstract \`the (fem. pl.)\` chips with no elicitation, and the avatar looping on one question pattern when the user got stuck).

### 1. Seed audit — disambiguate duplicate English labels (\`app/data/seed_bank.py\`)

Six encounters had two word chips sharing the same English label, so the FE rendered them as visually identical chips with no way to tell which one ticked:

| Encounter | Spanish pair | Old labels | New labels |
|-----------|--------------|------------|------------|
| \`air_15\` | retraso / demora | delay / delay | delay / **delay (alt.)** |
| \`bank_5\` | PIN / clave | PIN / PIN | PIN / **PIN/code** |
| \`bank_16\` | monto / cantidad | amount / amount | amount / **quantity** |
| \`contr_8\` | retraso / atraso | delay / delay | delay / **delay (alt.)** |
| \`rest_1\` | menú / carta | menu / menu | menu / **menu (à la carte)** |
| \`rest_7\` | acompañamiento / guarnición | side dish / side dish | side dish / **garnish** |

New test in \`test_seed_data.py\` (\`TestNoDuplicateEnglishLabelsPerEncounter\`) sweeps all 547 encounters and locks the audit in.

### 2. Article elicitation hints (\`app/services/grammar_elicitation.py\`)

Extends the \`VOCAB_ELICITATION_HINTS\` table (introduced in #32 for reflexives + \`del\`/\`al\`) with 4 article patterns:

- \`(masc.)\` → \`el\`, \`un\`
- \`(fem.)\` → \`la\`, \`una\`
- \`(masc. pl.)\` → \`los\`
- \`(fem. pl.)\` → \`las\`

Each hint instructs the LLM to ask a content question whose natural answer is a noun phrase requiring the matching article (e.g. \`¿Cuál es el problema?\` → \`el problema es…\`). Plurals listed first in the tuple so they're not shadowed by the bare-gender patterns. Plain lexical chips (\`bottle\`, \`gate\`) still get no hint.

### 3. Anti-stuck tactics menu (\`app/services/voice_turn_service.py\`)

Two changes to \`_render_anti_stuck_rule\`:

- **Threshold lowered**: nudge fires at \`n=1\` (was \`n=2\`). A native-English learner gets explicit scaffolding after one stuck turn rather than two.
- **Tactics menu**: replaces the single \`fill-in / yes-no\` instruction with a 5-item rotating menu so the LLM stops looping on one elicitation pattern:
  1. Synonym setup
  2. Define-without-saying
  3. Contrast (\`Mi vuelo está a tiempo — ¿y el suyo?\`)
  4. Fill-in-blank
  5. Embedded yes/no (last resort)

Translate threshold (\`n=3\`) is unchanged — last-resort English glossing still requires three stuck turns.

## Relationship to PR #32

This branch contains the role-fidelity rule + reflexive/\`del\`/\`al\` elicitation hints from #32 (cherry-picked). Recommend closing #32 in favour of this PR rather than maintaining two parallel branches that touch the same files.

## Frontend follow-ups (not in this PR)

The user also asked for two FE-side changes that aren't in this BE PR:

- **Mission card** before each encounter (\"Tu vuelo está retrasado. Averigua: a) la nueva hora, b) tu puerta…\") to position the user as the asker and remove the \"invent context\" load.
- **Proactive Need-help expansion** after one stuck turn — the BE already exposes \`consecutive_no_progress_turns\`, the FE just needs to react.

If these are wanted, happy to do them in a sibling PR against \`SpanishForExpats_FE\`.

## Test plan

- [x] \`pytest tests/test_seed_data.py --noconftest\` — new \`TestNoDuplicateEnglishLabelsPerEncounter\` plus existing 25 tests
- [x] \`pytest tests/test_services/test_grammar_elicitation.py --noconftest\` — 24 passed (5 new article tests + 19 existing)
- [x] \`pytest tests/test_services/test_anti_stuck_rule.py --noconftest\` — 9 new tests covering threshold + menu rendering
- [x] \`pytest tests/test_prompts.py --noconftest\` — 26 passed (no regressions; one stale comment updated)
- [x] \`pytest tests/test_services/test_avatar_validator.py tests/test_encounter_messages.py --noconftest\` — 70 passed (no regressions)
- [ ] Manual QA: replay airport encounter 15 — confirm chips show \`delay\` and \`delay (alt.)\`, and confirm the avatar reaches for menu tactics rather than the same question after a stuck turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)