### PR TITLE
Fix 19 failing CI tests on qa

### DIFF
--- a/app/core/logger.py
+++ b/app/core/logger.py
@@ -42,8 +42,14 @@ def log_event(
     # Merge extra fields
     log_entry.update(extra)
     
-    # Always print JSON to stdout (Railway/Better Stack will capture)
-    print(json.dumps(log_entry), file=sys.stdout, flush=True)
+    # Always print JSON to stdout (Railway/Better Stack will capture).
+    # `default=str` so UUIDs/datetimes/etc. coming through `user_id` or `extra`
+    # don't crash the global exception handlers — endpoints set
+    # `request.state.user_id = current_user.id` (a UUID) and we read that back
+    # here when an HTTPException bubbles up. Without `default=str` the dumps
+    # raises TypeError, which then re-enters the exception path and masks the
+    # original 4xx/5xx with an opaque 500.
+    print(json.dumps(log_entry, default=str), file=sys.stdout, flush=True)
     
     # Additionally ship to Better Stack asynchronously (fire-and-forget)
     schedule_ship_log(log_entry)

--- a/app/services/sentence_hint_service.py
+++ b/app/services/sentence_hint_service.py
@@ -149,6 +149,9 @@ def _grammar_pending_items(
         conjugated = (answers.get(verb) or {}).get(pronoun)
         if not conjugated:
             continue
+        # `|` is a stem/ending separator used only for UI rendering of drill
+        # answers; the LLM and any downstream consumer must see the plain form.
+        conjugated = conjugated.replace("|", "")
         items.append(
             PendingItem(
                 kind="grammar",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,10 +20,22 @@ TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engin
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_database():
-    """Create all tables once per test session, drop after."""
+    """Create all tables once per test session, drop after.
+
+    Teardown uses `DROP SCHEMA public CASCADE` rather than
+    `Base.metadata.drop_all` because some tables (e.g. `pron_daily_usage`)
+    are managed by Alembic and never registered on `Base.metadata`. Without
+    cascade, dropping `users` fails with `DependentObjectsStillExist` when
+    one of those alembic-only tables holds an FK to it.
+    """
+    from sqlalchemy import text
+
     Base.metadata.create_all(bind=engine)
     yield
-    Base.metadata.drop_all(bind=engine)
+    with engine.connect() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+        conn.commit()
 
 
 @pytest.fixture

--- a/tests/test_grammar_gating.py
+++ b/tests/test_grammar_gating.py
@@ -330,16 +330,16 @@ def test_gated_above_threshold():
 
 
 def test_not_gated_after_completing_grammar():
-    """GL=1, VL=10 → not gated (next is GL 2 at VL 15, 10 < 15)."""
-    assert get_next_gate(1, 10) is None
+    """GL=1.5, VL=10 → not gated (next is GL 2 at VL 15, 10 < 15)."""
+    assert get_next_gate(1.5, 10) is None
 
 
 def test_gated_on_next_level():
-    """GL=1, VL=15 → gated on GL 2 (Grammatical Gender)."""
-    gate = get_next_gate(1, 15)
+    """GL=1, VL=10 → gated on GL 1.5 (Possessive Adjectives, also at VL=10)."""
+    gate = get_next_gate(1, 10)
     assert gate is not None
-    assert gate["grammar_level"] == 2
-    assert gate["title"] == "Grammatical Gender"
+    assert gate["grammar_level"] == 1.5
+    assert gate["title"] == "Possessive Adjectives"
 
 
 def test_coming_soon_gate():
@@ -399,7 +399,7 @@ def test_gated_on_preterite_after_coming_soon_cleared():
     assert gate["grammar_level"] == 17
     assert gate["title"] == "Preterite Regular"
     assert gate["has_content"] is True
-    assert gate["situation_id"] == "grammar_preterite_regular_1"
+    assert gate["situation_id"] == "grammar_preterite_regular_hablar_encontrar_1"
 
 
 def test_not_gated_between_thresholds():
@@ -415,11 +415,16 @@ def test_gated_at_exact_boundary():
 
 
 def test_gl_at_float_boundary():
-    """GL=4 (not 4.5), VL=240 → gated on GL 4.5 (Irregular Present II)."""
+    """GL=4, VL=240 → gated on the next sub-level above 4 (GL 4.1, Ser vs. Estar).
+
+    `get_next_gate` returns the first GL above current_gl whose VL threshold
+    has been reached, regardless of whether content has shipped yet — callers
+    decide how to handle `has_content=False` placeholders.
+    """
     gate = get_next_gate(4, 240)
     assert gate is not None
-    assert gate["grammar_level"] == 4.5
-    assert gate["title"] == "Irregular Present II"
+    assert gate["grammar_level"] == 4.1
+    assert gate["title"] == "Ser vs. Estar"
 
 
 # ===========================================================================
@@ -446,11 +451,17 @@ def test_all_grammar_situations_have_valid_gl():
 
 
 def test_vl_thresholds_are_monotonically_increasing():
-    """VL thresholds increase as GL increases."""
+    """VL thresholds are non-decreasing as GL increases.
+
+    Sub-levels (1.5, 4.1–4.4, 5.5, 13.5, 17.1–17.5) often share the parent
+    level's VL threshold by design — they unlock together rather than
+    introducing a stricter vocab gate. The invariant is that thresholds
+    never go *down* as GL increases.
+    """
     prev_vl = -1
     for gl in GL_SORTED:
         vl = GL_VL_THRESHOLDS[gl]
-        assert vl > prev_vl, f"VL threshold not increasing: GL {gl} has VL {vl}, prev was {prev_vl}"
+        assert vl >= prev_vl, f"VL threshold decreased: GL {gl} has VL {vl}, prev was {prev_vl}"
         prev_vl = vl
 
 
@@ -522,8 +533,10 @@ def test_quiz_g101_assigns_gl_3(db):
 
     completed = _auto_complete_grammar(db, user.id, target_gl)
     db.flush()  # autoflush=False in test sessions
-    # GL 1 (1 sit) + GL 2 (1 sit) + GL 3 (3 lessons) = 5 situations
-    assert completed == 5
+    # All situations at GL <= 3, sourced from GRAMMAR_SITUATIONS so the
+    # assertion tracks curriculum growth instead of a hard-coded count.
+    expected = sum(1 for cfg in GRAMMAR_SITUATIONS.values() if cfg["grammar_level"] <= 3)
+    assert completed == expected
     assert get_grammar_level(db, user.id) == 3
 
 
@@ -601,10 +614,10 @@ def test_full_gating_flow_beginner(db):
     assert gate["grammar_level"] == 1
     assert gate["title"] == "Pronouns"
 
-    # Complete Pronouns
-    _complete_grammar(db, user, 1)
+    # Complete Pronouns and Possessive Adjectives (GL 1 and 1.5 both gate at VL=10)
+    _complete_grammar(db, user, 1.5)
     gl = get_grammar_level(db, user.id)
-    assert gl == 1
+    assert gl == 1.5
 
     # No longer gated (next GL 2 needs VL 15, we only have 10)
     assert get_next_gate(gl, vl) is None

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,83 @@
+"""Regression tests for app.core.logger.
+
+The structured logger sits in the global exception handler path, so a
+serialization crash here masks every 4xx/5xx the API ever returns and
+surfaces an opaque 500 instead. The tests below pin the contract that
+common non-JSON-native types (UUID, datetime) survive a `log_event`
+call without raising.
+"""
+import json
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from app.core.logger import log_event
+
+
+def _captured_stdout(monkeypatch_target_print):
+    """Wrap `print` so we can assert what `log_event` emits."""
+    captured = []
+
+    def fake_print(payload, **_kwargs):
+        captured.append(payload)
+
+    return captured, fake_print
+
+
+def test_log_event_serializes_uuid_user_id():
+    """`request.state.user_id` is sometimes set to `current_user.id` (a UUID).
+    The handler must not crash when that bubbles into `log_event`."""
+    user_id = uuid.uuid4()
+    captured = []
+
+    with patch("app.core.logger.print", lambda payload, **_: captured.append(payload)):
+        log_event(
+            level="info",
+            event="unit_test",
+            message="m",
+            request_id="req-1",
+            user_id=user_id,  # type: ignore[arg-type]  — intentional: simulate UUID leak
+        )
+
+    assert captured, "log_event should have emitted exactly one line"
+    parsed = json.loads(captured[0])
+    assert parsed["user_id"] == str(user_id)
+
+
+def test_log_event_serializes_uuid_in_extra():
+    """UUIDs that ride along in `extra` (e.g. conversation_id) must also not
+    crash dumps — the global handler injects `query_params` and similar."""
+    conv_id = uuid.uuid4()
+    captured = []
+
+    with patch("app.core.logger.print", lambda payload, **_: captured.append(payload)):
+        log_event(
+            level="warning",
+            event="unit_test",
+            message="m",
+            request_id="req-2",
+            extra={"conversation_id": conv_id, "nested": {"id": conv_id}},
+        )
+
+    parsed = json.loads(captured[0])
+    assert parsed["conversation_id"] == str(conv_id)
+    assert parsed["nested"] == {"id": str(conv_id)}
+
+
+def test_log_event_serializes_datetime_in_extra():
+    """Same defense for datetime — Pydantic models hand these out routinely."""
+    ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    captured = []
+
+    with patch("app.core.logger.print", lambda payload, **_: captured.append(payload)):
+        log_event(
+            level="info",
+            event="unit_test",
+            message="m",
+            request_id="req-3",
+            extra={"created_at": ts},
+        )
+
+    parsed = json.loads(captured[0])
+    # `default=str` calls str() on datetime, which yields ISO-ish output.
+    assert "2026-01-02" in parsed["created_at"]

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -17,7 +17,7 @@ import uuid
 
 import pytest
 
-from app.models import Conversation, Situation, Subscription, UserSituation
+from app.models import Conversation, Situation, UserSituation
 from app.services.realtime_session_service import (
     _reset_rate_limit_state_for_tests,
 )
@@ -269,9 +269,8 @@ def test_create_session_paywall_blocks_exhausted_free_user(
     _seed_banking_situation(db)
     conv = _make_voice_conversation(db, user_id)
 
-    # Give the user an inactive subscription (default) and N completed
-    # non-grammar encounters to trip the gate.
-    db.add(Subscription(user_id=user_id, active=False))
+    # `create_user` already inserts a default inactive Subscription on register,
+    # so we only need to seed N completed non-grammar encounters to trip the gate.
     for i in range(FREE_ENCOUNTERS_LIMIT):
         sit = Situation(
             id=f"bank_paywall_{i}",

--- a/tests/test_sentence_hint.py
+++ b/tests/test_sentence_hint.py
@@ -55,10 +55,15 @@ def _seed_vocab_situation(db):
 def _seed_grammar_situation(db):
     """Use an existing grammar situation id from grammar_situations.py so
     `get_grammar_config` resolves and returns drill_targets.
+
+    The original `grammar_regular_present_1` lesson was split into
+    `_ar_1`/`_er_1`/`_ir_1` variants (one per conjugation class) when the
+    Regular Present curriculum expanded. We pick the AR variant because it
+    drills `hablar` — the verb the test downstream asserts against.
     """
     sit = Situation(
-        id="grammar_regular_present_1",
-        title="Regular Present (1/3)",
+        id="grammar_regular_present_ar_1",
+        title="Regular Present AR (1/2)",
         animation_type="grammar",
         encounter_number=300,
         order_index=1300,
@@ -68,8 +73,7 @@ def _seed_grammar_situation(db):
     db.add(sit)
     db.add_all([
         Word(id="grammar_hablar", spanish="hablar", english="to speak", word_category="grammar"),
-        Word(id="grammar_beber", spanish="beber", english="to drink", word_category="grammar"),
-        Word(id="grammar_vivir", spanish="vivir", english="to live", word_category="grammar"),
+        Word(id="grammar_escuchar", spanish="escuchar", english="to listen", word_category="grammar"),
     ])
     db.flush()
     return sit
@@ -183,8 +187,8 @@ def test_sentence_hint_grammar_emits_conjugation_candidates(
     user_id = _get_auth_user_id(headers)
     _seed_grammar_situation(db)
     conv = _make_voice_conv(
-        db, user_id, "grammar_regular_present_1",
-        target_word_ids=["grammar_hablar", "grammar_beber", "grammar_vivir"],
+        db, user_id, "grammar_regular_present_ar_1",
+        target_word_ids=["grammar_hablar", "grammar_escuchar"],
     )
     db.commit()
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -1,4 +1,5 @@
 from tests.conftest import register_user
+from app.services.subscription_service import FREE_ENCOUNTERS_LIMIT
 
 
 def test_get_subscription_status(client, seed_data):
@@ -7,5 +8,5 @@ def test_get_subscription_status(client, seed_data):
     assert resp.status_code == 200
     data = resp.json()
     assert data["active"] is False
-    assert data["free_situations_limit"] == 25
-    assert data["free_situations_remaining"] == 25
+    assert data["free_situations_limit"] == FREE_ENCOUNTERS_LIMIT
+    assert data["free_situations_remaining"] == FREE_ENCOUNTERS_LIMIT


### PR DESCRIPTION
## Summary

CI on `qa` was failing with **19 fails + 1 error** across six independent groups. This PR resolves all of them.

### Commits

1. **`b7eceef` Logger: serialize UUID/datetime via json.dumps default=str**
   Cherry-picked from `main` (PR #19). When an endpoint set `request.state.user_id = current_user.id` (UUID) and later raised `HTTPException`, the global handler called `log_event` → `json.dumps(...)` and crashed on the UUID, masking every 4xx as a 500. Fixes ~10 failures in `test_realtime.py` and `test_realtime_turn.py`.

2. **`a1f2bfe` Tests: realign with new curriculum, paywall + free-tier changes**
   Six independent realignments:
   - **`test_grammar_gating`** — GL 1.5 "Possessive Adjectives" was added at VL=10 (same as GL 1), and `grammar_preterite_regular_1` was split into `_hablar_encontrar_1` etc. Tests using the old IDs and the strict-monotonicity invariant updated. The G101 quiz expected count is now sourced from `GRAMMAR_SITUATIONS` so curriculum growth tracks itself.
   - **`test_realtime` paywall test** — `create_user` already inserts a default inactive `Subscription`; the explicit `db.add(Subscription(...))` was a duplicate-key crash. Removed.
   - **`test_subscription`** — `FREE_ENCOUNTERS_LIMIT` dropped 25→7 in 179c9c7. Pull the constant from the service so the test follows config.
   - **`test_sentence_hint` grammar path** — `grammar_regular_present_1` was split into per-conjugation variants; without a config match the service silently fell back to the vocab path. Switched to `grammar_regular_present_ar_1` (drills `hablar`).
   - **`app/services/sentence_hint_service.py`** — `_grammar_pending_items` was leaking the `|` UI render marker (`habl|o`) into the LLM prompt and the FE response. Strip it at the boundary. *(Real bug fix, not test-only.)*
   - **`tests/conftest.py` teardown** — `pron_daily_usage` is alembic-managed and missing from `Base.metadata`, so `drop_all` hit `DependentObjectsStillExist` on `users` once Alembic ran in CI. Switched to `DROP SCHEMA public CASCADE`.

## Test plan
- [x] CI green on this branch (already verified at `a1f2bfe` before splitting: run `25289065921`, 1m59s, 924 passed)
- [ ] Re-run CI on this branch via PR
- [ ] After merge: confirm Railway QA still deploys clean