### PR TITLE
Promote qa → main: fix onboarding crash on unseeded grammar situations

### DIFF
--- a/app/api/v1/onboarding.py
+++ b/app/api/v1/onboarding.py
@@ -116,16 +116,38 @@ def _seed_hf_words(db: Session, user_id, count: int) -> int:
 
 
 def _auto_complete_grammar(db: Session, user_id, target_gl: float, skip_gls: set[float] | None = None) -> int:
-    """Auto-complete grammar situations whose grammar_level <= target_gl, skipping any in skip_gls."""
+    """Auto-complete grammar situations whose grammar_level <= target_gl, skipping any in skip_gls.
+
+    Skips static GRAMMAR_SITUATIONS keys not present in the situations table —
+    inserting a UserSituation for an unseeded id raises a FK violation that
+    crashes the entire onboarding request (see Jono signup, May 2026). The
+    surviving rows still let onboarding finish; the missing situations should
+    be reseeded out-of-band via scripts/seed_missing_grammar_situations.py.
+    """
     skip_gls = skip_gls or set()
     now = datetime.now(timezone.utc)
     completed = 0
 
-    for sid in get_all_grammar_situation_ids():
-        cfg = GRAMMAR_SITUATIONS[sid]
-        if cfg["grammar_level"] > target_gl:
-            continue
-        if cfg["grammar_level"] in skip_gls:
+    candidate_ids = [
+        sid for sid in get_all_grammar_situation_ids()
+        if GRAMMAR_SITUATIONS[sid]["grammar_level"] <= target_gl
+        and GRAMMAR_SITUATIONS[sid]["grammar_level"] not in skip_gls
+    ]
+    if not candidate_ids:
+        return 0
+
+    seeded_ids = {
+        row[0] for row in db.query(Situation.id).filter(Situation.id.in_(candidate_ids)).all()
+    }
+    missing = [sid for sid in candidate_ids if sid not in seeded_ids]
+    if missing:
+        logger.warning(
+            "Onboarding skipping unseeded grammar situations (run seed_missing_grammar_situations.py): %s",
+            missing,
+        )
+
+    for sid in candidate_ids:
+        if sid not in seeded_ids:
             continue
 
         existing = db.query(UserSituation).filter(

--- a/app/api/v1/situations.py
+++ b/app/api/v1/situations.py
@@ -777,6 +777,14 @@ async def admin_complete_for_user(
     if not target_user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
+    # Validate the situation_id exists — otherwise the insert below hits a
+    # ForeignKeyViolation that surfaces as an opaque 500.
+    if not db.query(Situation.id).filter(Situation.id == request.situation_id).first():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Situation not found: {request.situation_id}",
+        )
+
     from datetime import datetime
     now = datetime.utcnow()
     user_situation = db.query(UserSituation).filter(

--- a/scripts/seed_missing_grammar_situations.py
+++ b/scripts/seed_missing_grammar_situations.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Idempotently seed any GRAMMAR_SITUATIONS keys that are missing from the
+`situations` table (and the matching grammar `words` + `situation_words`
+rows). Non-destructive — never touches existing rows or any non-grammar data.
+
+Why this exists: `_auto_complete_grammar` in onboarding.py loops the static
+GRAMMAR_SITUATIONS dict and inserts user_situations referencing each id. If
+prod was deployed without a corresponding situations-table seed (e.g. a new
+grammar lesson was added in code but the seed step was forgotten), every
+new signup hits a ForeignKeyViolation mid-onboarding. This script closes
+that gap without the destructive replace that migrate_grammar_prod.py does.
+
+Usage:
+    DATABASE_URL=... python scripts/seed_missing_grammar_situations.py --dry-run
+    DATABASE_URL=... python scripts/seed_missing_grammar_situations.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import sessionmaker
+
+from app.config import settings
+from app.data.grammar_situations import (
+    GRAMMAR_SITUATIONS,
+    GRAMMAR_WORD_TRANSLATIONS,
+    GL_VL_THRESHOLDS,
+)
+from app.models import Situation, SituationWord, Word
+
+DRY_RUN = "--dry-run" in sys.argv
+ORDER_OFFSET = 1000  # mirrors migrate_grammar_prod.py
+
+
+def main() -> int:
+    engine = create_engine(settings.database_url, pool_pre_ping=True)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as db:
+        existing_ids = {sid for (sid,) in db.query(Situation.id).filter(
+            Situation.id.in_(list(GRAMMAR_SITUATIONS.keys()))
+        ).all()}
+        missing_ids = [sid for sid in GRAMMAR_SITUATIONS.keys() if sid not in existing_ids]
+
+        print(f"GRAMMAR_SITUATIONS keys: {len(GRAMMAR_SITUATIONS)}")
+        print(f"Already seeded: {len(existing_ids)}")
+        print(f"Missing from DB: {len(missing_ids)}")
+        for sid in missing_ids:
+            cfg = GRAMMAR_SITUATIONS[sid]
+            print(f"  {sid:50s}  GL={cfg['grammar_level']}  '{cfg['title']}'")
+
+        if not missing_ids:
+            print("\nNothing to seed.")
+            return 0
+
+        if DRY_RUN:
+            print("\n=== DRY RUN — no changes made ===")
+            return 0
+
+        # Insert grammar Word rows for any words referenced by missing
+        # situations that aren't already in the words table. on_conflict_do_nothing
+        # leaves any pre-existing translations alone.
+        words_inserted = 0
+        seen_words: set[str] = set()
+        for sid in missing_ids:
+            for word in GRAMMAR_SITUATIONS[sid]["word_workload"]:
+                if word in seen_words:
+                    continue
+                seen_words.add(word)
+                word_id = f"grammar_{word}"
+                english = GRAMMAR_WORD_TRANSLATIONS.get(word, word)
+                stmt = insert(Word).values(
+                    id=word_id,
+                    spanish=word,
+                    english=english,
+                    word_category="grammar",
+                ).on_conflict_do_nothing(index_elements=["id"])
+                result = db.execute(stmt)
+                if result.rowcount:
+                    words_inserted += 1
+        print(f"\nInserted {words_inserted} new grammar word rows")
+
+        # Insert the missing situations + their situation_words mapping.
+        for sid in missing_ids:
+            cfg = GRAMMAR_SITUATIONS[sid]
+            gl = cfg["grammar_level"]
+            order_key = int(gl * 100)
+            stmt = insert(Situation).values(
+                id=sid,
+                title=cfg["title"],
+                animation_type="grammar",
+                encounter_number=order_key,
+                order_index=ORDER_OFFSET + order_key,
+                is_free=True,
+                situation_type="grammar",
+                vocab_level_required=GL_VL_THRESHOLDS.get(gl, 0),
+                video_embed_id=cfg["video_embed_id"],
+            ).on_conflict_do_nothing(index_elements=["id"])
+            db.execute(stmt)
+
+            for pos, word in enumerate(cfg["word_workload"], 1):
+                word_id = f"grammar_{word}"
+                stmt = insert(SituationWord).values(
+                    situation_id=sid, word_id=word_id, position=pos
+                ).on_conflict_do_nothing()
+                db.execute(stmt)
+
+        db.commit()
+        print(f"Inserted {len(missing_ids)} grammar situation rows")
+        print("\n=== Seed complete ===")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- `_auto_complete_grammar` and `admin_complete_for_user` now check `situations` table membership before inserting `user_situations`, preventing FK violations from crashing onboarding (Jono signup, "Load failed").
- Adds idempotent `scripts/seed_missing_grammar_situations.py` for closing static-config ↔ DB drift without destructive ops.
- Prod DB has already been reseeded (5/209 → 209/209), so the FK class of bug is already gone today; this PR promotes the belt-and-suspenders code guard.

## Test plan
- [x] QA branch deployed to Railway QA, BE healthy
- [x] Browser-driven signup via FE wizard → dashboard rendered (VL=2500, GL=11)
- [x] 8 programmatic signups across GL 2 → 18.5, all 200 OK
- [x] Transaction-rolled-back drift simulation: monkeypatched fake unseeded id; guard skipped + logged warning instead of FK-crashing
- [x] Prod seed dry-run + real run + post-verify all clean (209/209)

🤖 Generated with [Claude Code](https://claude.com/claude-code)