### PR TITLE
Voice chat: lesson-context block in realtime system prompt

### DIFF
--- a/app/api/v1/conversations.py
+++ b/app/api/v1/conversations.py
@@ -780,10 +780,21 @@ async def voice_turn_respond(
         target_word_objects=words,
     )
 
+    # Lesson-context: pass English glosses of pending vocab chips into
+    # the role prompt so the avatar steers toward natural opportunities
+    # to elicit them. Grammar chips (with verb+pronoun) are filtered out
+    # — those have working steering via `_PRONOUN_INSTRUCTIONS`.
+    lesson_concepts = [
+        chip.english.strip()
+        for chip in (learner_ctx.target_chips or [])
+        if chip.english and not chip.is_grammar
+    ] if learner_ctx else []
+
     system_prompt = build_realtime_system_prompt(
         situation.animation_type if situation else "",
         conversation.situation_id,
         alt_language=alt_language,
+        lesson_concepts=lesson_concepts,
     )
 
     # Build messages: [system, ...history, user]. We always include the

--- a/app/prompts/prompts.json
+++ b/app/prompts/prompts.json
@@ -17,6 +17,6 @@
   },
   "realtime_agent": {
     "prompt_version": "v1",
-    "content": "You are {ai_role}, speaking to {user_role}. {situation_description}. You only speak in very simple {language}. At most two short sentences. Keep the conversation going."
+    "content": "You are {ai_role}, speaking to {user_role}. {situation_description}.{lesson_block} You only speak in very simple {language}. At most two short sentences. Keep the conversation going."
   }
 }

--- a/app/services/realtime_config.py
+++ b/app/services/realtime_config.py
@@ -97,10 +97,24 @@ def _resolve_system_prompt(
     signature compatibility with `build_session_config` callers but
     aren't currently consumed by the realtime template.
     """
+    # Lesson-context: pass English glosses of pending vocab chips into
+    # the role prompt. Grammar chips are skipped — those have their own
+    # per-turn steering via `_PRONOUN_INSTRUCTIONS`.
+    lesson_concepts = (
+        [
+            chip.english.strip()
+            for chip in (learner_ctx.target_chips or [])
+            if chip.english and not chip.is_grammar
+        ]
+        if learner_ctx
+        else []
+    )
+
     return build_realtime_system_prompt(
         situation.animation_type,
         conversation.situation_id,
         alt_language=alt_language,
+        lesson_concepts=lesson_concepts,
     )
 
 

--- a/app/services/voice_turn_service.py
+++ b/app/services/voice_turn_service.py
@@ -280,10 +280,44 @@ def build_system_prompt(
     )
 
 
+def _render_lesson_block(concepts: Optional[List[str]]) -> str:
+    """Render the lesson-context line dropped into the realtime prompt.
+
+    `concepts` is a list of English glosses for the words/phrases the
+    student is practicing in this encounter (e.g. ['boarding', 'gate',
+    'departure time']). When non-empty, returns a leading-space block
+    that names the concepts and asks the avatar to create natural
+    opportunities for the student to produce them.
+
+    Why English-only: the user (learner) is the one who must produce
+    the target language. Putting Spanish forms in the prompt risks
+    parroting and prevents the student from earning the chip. The
+    English glosses are the semantic anchor; the model translates
+    intent into its conversation language by itself.
+
+    Returns empty string when `concepts` is None or empty — keeps the
+    prompt clean for grammar chats and other call paths that don't
+    have a vocab lesson to highlight.
+    """
+    if not concepts:
+        return ""
+    cleaned = [c.strip() for c in concepts if c and c.strip()]
+    if not cleaned:
+        return ""
+    joined = ", ".join(cleaned)
+    return (
+        f" The student is practicing how to talk about these concepts: "
+        f"{joined}. Steer the conversation so they have natural "
+        f"opportunities to bring them up — do not tell them what to say "
+        f"and do not produce the target-language form yourself."
+    )
+
+
 def build_realtime_system_prompt(
     animation_type: str,
     situation_id: str,
     alt_language: Optional[str] = None,
+    lesson_concepts: Optional[List[str]] = None,
 ) -> str:
     """Short, role-only system prompt for the realtime steering experiment.
 
@@ -295,6 +329,12 @@ def build_realtime_system_prompt(
     Loads `realtime_agent` v1 from prompts.json and renders it with the
     same role lookup the v3 templates use (vocab → SITUATION_ROLES, grammar
     → GRAMMAR_SCENE_MAP → SITUATION_ROLES).
+
+    `lesson_concepts` is the list of English glosses for the vocab the
+    student is practicing in this encounter. When provided, a one-line
+    block is injected after `situation_description` telling the avatar
+    what concepts to steer toward. Pass an empty list (or None) for
+    grammar chats and other paths where vocab steering doesn't apply.
     """
     from app.services.llm_gateway import load_prompt
 
@@ -306,6 +346,7 @@ def build_realtime_system_prompt(
         user_role=roles["user_role"],
         situation_description=roles["situation_description"],
         language=language,
+        lesson_block=_render_lesson_block(lesson_concepts),
     )
 
 

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -195,11 +195,10 @@ def test_create_session_happy_path(client, db, auth_user, fake_httpx):
     posted = fake_httpx.last_call["json"]
     assert posted["model"] == "gpt-realtime-mini"
     assert posted["voice"] == "shimmer"  # banking situation
-    assert posted["turn_detection"] == {
-        "type": "server_vad",
-        "threshold": 0.5,
-        "silence_duration_ms": 500,
-    }
+    # turn_detection is None (push-to-talk) per commit 64eb21c — the FE
+    # commits the audio buffer + fires response.create itself instead of
+    # relying on server VAD endpointing.
+    assert posted["turn_detection"] is None
     assert posted["input_audio_transcription"] == {"model": "whisper-1"}
     assert fake_httpx.last_call["url"] == (
         "https://api.openai.com/v1/realtime/sessions"

--- a/tests/test_sentence_hint.py
+++ b/tests/test_sentence_hint.py
@@ -4,8 +4,11 @@ After the TTS/R2 strip the contract is:
     request:  { messages_json?: stringified [{role, content}] }
     response: { english_gloss: str, hints_remaining: int }
 
-Covers happy path + cap (5/conv) + the two 409 cases. Upstream LLM call
-is monkeypatched. No TTS, no R2.
+Covers happy path + cap-removed sentinel + the two 409 cases. The
+per-conversation cap was removed in commit e4e0f19; the BE now returns
+a fixed `hints_remaining=999` sentinel so the FE keeps rendering its
+counter without a special case. Upstream LLM call is monkeypatched. No
+TTS, no R2.
 """
 import uuid
 
@@ -83,13 +86,20 @@ def test_sentence_hint_happy_path(client, db, auth_user, monkeypatch):
     )
     assert r.status_code == 200, r.text
     body = r.json()
+    # `hints_remaining` is a fixed sentinel post-cap-removal (e4e0f19) —
+    # the FE counter keeps rendering, but there is no per-conversation
+    # ceiling enforced server-side.
     assert body == {
         "english_gloss": "Could you open an **account** for me?",
-        "hints_remaining": 4,
+        "hints_remaining": 999,
     }
 
 
-def test_sentence_hint_cap_blocks_sixth(client, db, auth_user, monkeypatch):
+def test_sentence_hint_no_per_conversation_cap(client, db, auth_user, monkeypatch):
+    """The per-conversation hint cap was removed in commit e4e0f19. Pin
+    that callers can keep requesting hints without hitting a 429 — the
+    sentinel `hints_remaining` stays positive across many calls.
+    """
     _, headers = auth_user
     sit = _seed_vocab_situation(db)
     conv = _make_voice_conv(
@@ -102,21 +112,15 @@ def test_sentence_hint_cap_blocks_sixth(client, db, auth_user, monkeypatch):
 
     _stub_llm(monkeypatch)
 
-    for _ in range(5):
+    # Six calls — would have tripped the old 5-cap; should all succeed now.
+    for _ in range(6):
         r = client.post(
             f"/v1/conversations/{conv.id}/sentence-hint",
             headers=headers,
             json={},
         )
         assert r.status_code == 200, r.text
-
-    r = client.post(
-        f"/v1/conversations/{conv.id}/sentence-hint",
-        headers=headers,
-        json={},
-    )
-    assert r.status_code == 429
-    assert r.json()["detail"] == "HINT_RATE_LIMIT"
+        assert r.json()["hints_remaining"] > 0
 
 
 def test_sentence_hint_409_when_all_words_detected(client, db, auth_user, monkeypatch):

--- a/tests/test_services/test_realtime_config.py
+++ b/tests/test_services/test_realtime_config.py
@@ -103,9 +103,11 @@ def test_resolve_voice_unknown_animation_type_falls_back():
 
 
 def test_ephemeral_config_carries_model_vad_and_whisper(db):
-    """Ephemeral config (browser → OpenAI WebRTC) must include the model name,
-    server VAD turn detection, and whisper transcription. Without these the
-    browser session can't endpoint user speech or hand transcripts back to us."""
+    """Ephemeral config (browser → OpenAI WebRTC) must include the model
+    name, push-to-talk turn detection (null), and whisper transcription.
+    Without whisper the browser session can't hand transcripts back to us;
+    turn_detection=null since commit 64eb21c so the FE drives endpointing
+    itself via input_audio_buffer.commit + response.create."""
     user = _make_user(db)
     situation = _make_situation(db, "bank_open_test", "banking")
     conv = _make_conversation(db, user, situation)
@@ -115,11 +117,8 @@ def test_ephemeral_config_carries_model_vad_and_whisper(db):
     assert cfg["model"] == REALTIME_MODEL
     assert cfg["modalities"] == ["text", "audio"]
     assert cfg["voice"] == "shimmer"
-    assert cfg["turn_detection"] == {
-        "type": "server_vad",
-        "threshold": 0.5,
-        "silence_duration_ms": 500,
-    }
+    # Push-to-talk: server VAD is disabled.
+    assert cfg["turn_detection"] is None
     assert cfg["input_audio_transcription"] == {"model": "whisper-1"}
     assert isinstance(cfg["instructions"], str) and cfg["instructions"]
     # Ephemeral never sets output_audio_format — that's only meaningful when

--- a/tests/test_services/test_realtime_lesson_context.py
+++ b/tests/test_services/test_realtime_lesson_context.py
@@ -1,0 +1,96 @@
+"""Unit tests for the lesson-context block injected into the realtime
+system prompt.
+
+Pure-Python tests — no DB needed. Hit `_render_lesson_block` directly
+and `build_realtime_system_prompt` end-to-end with a known
+animation_type so the role lookup resolves.
+
+Run: python3.11 -m pytest tests/test_services/test_realtime_lesson_context.py --noconftest -v
+"""
+from __future__ import annotations
+
+from app.services.voice_turn_service import (
+    _render_lesson_block,
+    build_realtime_system_prompt,
+)
+
+
+class TestRenderLessonBlock:
+    def test_none_returns_empty_string(self):
+        assert _render_lesson_block(None) == ""
+
+    def test_empty_list_returns_empty_string(self):
+        assert _render_lesson_block([]) == ""
+
+    def test_list_with_only_blanks_returns_empty_string(self):
+        assert _render_lesson_block(["", "  ", "\t"]) == ""
+
+    def test_single_concept_renders_with_leading_space(self):
+        result = _render_lesson_block(["boarding"])
+        # The block must start with a space so it concatenates cleanly
+        # after `{situation_description}.` in the template.
+        assert result.startswith(" ")
+        assert "boarding" in result
+
+    def test_multiple_concepts_joined_by_comma(self):
+        result = _render_lesson_block(["boarding", "gate", "departure time"])
+        assert "boarding, gate, departure time" in result
+
+    def test_strips_whitespace_around_concepts(self):
+        result = _render_lesson_block(["  boarding  ", " gate"])
+        assert "boarding, gate" in result
+        # No double spaces or stray whitespace inside the joined list
+        assert "  " not in result.split("concepts: ")[1].split(".")[0]
+
+    def test_block_does_not_contain_spanish_target_forms(self):
+        # Regression guard for the policy: no Spanish in prompt content.
+        # Caller passes English glosses; the helper must not invent
+        # Spanish.
+        result = _render_lesson_block(["boarding", "gate"])
+        # Sanity checks — these would only appear if someone hardcoded
+        # Spanish examples in the helper.
+        assert "embarque" not in result
+        assert "puerta" not in result
+
+
+class TestBuildRealtimeSystemPrompt:
+    def test_no_lesson_concepts_renders_clean_prompt(self):
+        result = build_realtime_system_prompt(
+            animation_type="airport",
+            situation_id="air_12",
+            alt_language=None,
+            lesson_concepts=None,
+        )
+        # Role still renders
+        assert "airline check-in agent" in result
+        # No lesson-block content
+        assert "practicing how to talk about" not in result
+
+    def test_lesson_concepts_appear_in_prompt(self):
+        result = build_realtime_system_prompt(
+            animation_type="airport",
+            situation_id="air_12",
+            alt_language=None,
+            lesson_concepts=["boarding", "gate", "departure time"],
+        )
+        assert "practicing how to talk about" in result
+        assert "boarding, gate, departure time" in result
+        # Steering directive still present
+        assert "do not tell them what to say" in result
+
+    def test_empty_lesson_concepts_omits_block(self):
+        result = build_realtime_system_prompt(
+            animation_type="airport",
+            situation_id="air_12",
+            lesson_concepts=[],
+        )
+        assert "practicing how to talk about" not in result
+
+    def test_default_no_lesson_concepts_arg_omits_block(self):
+        # Call sites that haven't been updated yet must keep working.
+        result = build_realtime_system_prompt(
+            animation_type="airport",
+            situation_id="air_12",
+        )
+        assert "practicing how to talk about" not in result
+        assert "airline check-in agent" in result


### PR DESCRIPTION
## Summary

- Adds a `{lesson_block}` slot to the `realtime_agent` v1 prompt so the avatar knows what concepts the student just learned (English glosses only, no Spanish in the prompt).
- New helper `_render_lesson_block` in `voice_turn_service.py`; both call sites (legacy `/voice-turn/respond` and WebRTC realtime config) extract pending vocab-chip glosses from `learner_ctx` and pass them in. Grammar chips skipped — they already have working steering via `_PRONOUN_INSTRUCTIONS`.
- 11 unit tests covering helper edge cases, default-arg backward compatibility, and end-to-end builder behavior with the airport role.

## Why

Today the realtime system prompt is generic to the situation only — it doesn't know which encounter the user is in or which words they just learned. Vocab encounters drift to "How can I help you?" instead of creating opportunities to produce the target words. This change gives the avatar a steering directive in plain English without scripting Spanish content.

Step 1 of two — step 2 (per-situation scene script in `SITUATION_ROLES`) is a separate PR.

## Test plan

- [ ] Unit tests pass: \`python -m pytest tests/test_services/test_realtime_lesson_context.py --noconftest -v\`
- [ ] QA preview: pick a vocab encounter (e.g. airport encounter 12 with embarque / hora de embarque / hora de salida), open voice chat, observe whether the avatar's opening turn references those concepts naturally (asks about boarding times, gates, etc.) instead of generic "how can I help you?".
- [ ] Confirm grammar chats render the prompt unchanged (no lesson block appears since grammar chips are filtered out).
- [ ] Confirm the avatar does not produce the Spanish target form in its replies (chip-leak validator should not flag).

Refs the conversation drift issue we've been iterating on.