### PR TITLE
Realtime steering: per-turn instructions for vocab chips

### DIFF
--- a/app/services/realtime_steering.py
+++ b/app/services/realtime_steering.py
@@ -229,33 +229,90 @@ _PRONOUN_INSTRUCTIONS: Dict[str, tuple[str, str]] = {
 }
 
 
+_VOCAB_GENERIC_FALLBACK = (
+    'Ask the user a question whose natural answer requires them to say '
+    '"{spanish}" ({english}). Do NOT say "{spanish}" yourself — only the '
+    'user says it. Examples: if the target were "café" (coffee), ask '
+    '"¿Qué bebes en la mañana?". If it were "número de vuelo" (flight '
+    'number), ask "¿Cómo identifico su reserva?".'
+    + _BREVITY_TAG
+)
+
+
+def _build_vocab_response_instructions(
+    target_form: Dict[str, Any],
+) -> Optional[str]:
+    """Per-turn instructions for vocab chips (no pronoun/verb metadata).
+
+    Two paths:
+      1. The chip's English label matches a `VOCAB_ELICITATION_HINTS`
+         pattern (reflexives, contractions, gendered articles). Reuse the
+         hint string — it already encodes the elicitation strategy used
+         by the legacy `/voice-turn` flow's static target_steering block.
+      2. Plain lexical chip (`gate`, `gate number`, `passport`). Fall
+         back to a generic "ask a question whose natural answer requires
+         the form" template.
+
+    Returns None when the target form has no Spanish content; callers
+    should fire `response.create` with no override in that case.
+    """
+    from app.services.grammar_elicitation import _vocab_elicitation_hint
+    from app.services.learner_context import ChipTarget
+
+    spanish = (target_form.get("spanish") or "").strip()
+    english = (target_form.get("english") or "").strip()
+    if not spanish:
+        return None
+
+    chip = ChipTarget(
+        id=str(target_form.get("id") or ""),
+        spanish=spanish,
+        english=english,
+    )
+    hint = _vocab_elicitation_hint(chip)
+    if hint:
+        return hint + _BREVITY_TAG
+
+    return _VOCAB_GENERIC_FALLBACK.format(spanish=spanish, english=english)
+
+
 def build_response_instructions(target_form: Dict[str, Any]) -> Optional[str]:
     """Per-turn response.instructions override for the realtime steering.
 
-    Maps the chip's pronoun to a flipped pronoun + template, looks up the
-    flipped conjugation via grammar_situations.find_grammar_form, and
-    returns the rendered instruction. Returns None when:
-      - target lacks pronoun/verb metadata (vocab encounter, no override)
-      - the pronoun isn't in our flip map
-      - find_grammar_form can't resolve the flipped (verb, pronoun) pair
+    Two regimes:
 
-    Caller should fall through to firing response.create with no
-    instructions in those cases.
+    Grammar chips (target has both `pronoun` and `verb`): map the
+    pronoun to a flipped pronoun + template, look up the flipped
+    conjugation via `grammar_situations.find_grammar_form`, and return
+    the rendered instruction. Returns None when the pronoun isn't in
+    our flip map or the conjugation lookup fails.
+
+    Vocab chips (no pronoun/verb): hand off to
+    `_build_vocab_response_instructions`, which reuses
+    `VOCAB_ELICITATION_HINTS` for grammatical-artifact chips
+    (reflexives, contractions, gendered articles) and falls back to a
+    generic "set up a question whose answer requires X" template for
+    plain lexical chips. Returns None only when the target has no
+    Spanish content.
+
+    Callers fall through to firing `response.create` with no
+    instructions in any None case.
     """
     from app.data.grammar_situations import find_grammar_form
 
     pronoun = target_form.get("pronoun")
     verb = target_form.get("verb")
-    if not pronoun or not verb:
-        return None
-    rule = _PRONOUN_INSTRUCTIONS.get(pronoun)
-    if not rule:
-        return None
-    flipped_pronoun, template = rule
-    flipped_form = find_grammar_form(verb, flipped_pronoun)
-    if not flipped_form:
-        return None
-    return template.format(form=flipped_form, lemma=verb)
+    if pronoun and verb:
+        rule = _PRONOUN_INSTRUCTIONS.get(pronoun)
+        if not rule:
+            return None
+        flipped_pronoun, template = rule
+        flipped_form = find_grammar_form(verb, flipped_pronoun)
+        if not flipped_form:
+            return None
+        return template.format(form=flipped_form, lemma=verb)
+
+    return _build_vocab_response_instructions(target_form)
 
 
 def build_meta_thought(target_form: Dict[str, Any], language: str) -> str:

--- a/tests/test_services/test_realtime_steering.py
+++ b/tests/test_services/test_realtime_steering.py
@@ -1,0 +1,112 @@
+"""Pure-Python tests for realtime per-turn steering instructions.
+
+Covers the two regimes of `build_response_instructions`:
+
+- Grammar chips (with pronoun + verb): pronoun-flip template lookup.
+- Vocab chips (no pronoun): VOCAB_ELICITATION_HINTS reuse for
+  grammatical artifacts (reflexives, contractions, gendered articles)
+  and the generic fallback for plain lexical chips.
+
+Run: python3.11 -m pytest tests/test_services/test_realtime_steering.py --noconftest -v
+"""
+from __future__ import annotations
+
+from app.services.realtime_steering import (
+    _build_vocab_response_instructions,
+    build_response_instructions,
+)
+
+
+class TestBuildResponseInstructionsGrammar:
+    def test_yo_target_renders_tu_question_template(self):
+        out = build_response_instructions({
+            "id": "conj_comer_yo",
+            "spanish": "como",
+            "english": "I eat",
+            "pronoun": "yo",
+            "verb": "comer",
+        })
+        assert out is not None
+        # The yo→tú flip uses a "Ask the user a question" template.
+        assert "Ask the user" in out
+        # Conjugated tú-form is substituted in.
+        assert "comes" in out
+
+    def test_unknown_pronoun_returns_none(self):
+        out = build_response_instructions({
+            "id": "x",
+            "spanish": "cantamos",
+            "english": "we sing",
+            "pronoun": "vos",  # not in _PRONOUN_INSTRUCTIONS
+            "verb": "cantar",
+        })
+        assert out is None
+
+
+class TestBuildResponseInstructionsVocab:
+    def test_plain_lexical_chip_uses_generic_fallback(self):
+        out = build_response_instructions({
+            "id": "w_gate_number",
+            "spanish": "número de puerta",
+            "english": "gate number",
+        })
+        assert out is not None
+        # Generic fallback names both forms verbatim and forbids leak.
+        assert "número de puerta" in out
+        assert "gate number" in out
+        assert "Do NOT say" in out
+        # Brevity tag is appended.
+        assert "2 short sentences" in out
+
+    def test_masc_plural_article_chip_uses_hint(self):
+        out = build_response_instructions({
+            "id": "hf_26",
+            "spanish": "los",
+            "english": "the (masc. pl.)",
+        })
+        assert out is not None
+        # Comes from VOCAB_ELICITATION_HINTS: instructs an answer with
+        # masc.-plural article + noun.
+        assert "masc." in out
+        assert "plural" in out.lower()
+        # Brevity tag still appended on the hint path.
+        assert "2 short sentences" in out
+
+    def test_a_el_contraction_chip_uses_hint(self):
+        out = build_response_instructions({
+            "id": "hf_37",
+            "spanish": "al",
+            "english": "to the (a + el)",
+        })
+        assert out is not None
+        assert "masculine" in out.lower()
+        assert "Do NOT say" in out
+
+    def test_reflexive_chip_uses_hint(self):
+        out = build_response_instructions({
+            "id": "hf_27",
+            "spanish": "se",
+            "english": "oneself (reflexive)",
+        })
+        assert out is not None
+        assert "reflexive" in out.lower()
+
+    def test_missing_spanish_returns_none(self):
+        assert build_response_instructions({
+            "id": "x",
+            "spanish": "",
+            "english": "gate",
+        }) is None
+
+    def test_helper_called_directly_for_vocab(self):
+        # The vocab helper is the path used by realtime turns whenever
+        # the target lacks pronoun/verb metadata. Confirm it works
+        # without going through the dispatcher.
+        out = _build_vocab_response_instructions({
+            "id": "w_gate",
+            "spanish": "puerta",
+            "english": "gate",
+        })
+        assert out is not None
+        assert "puerta" in out
+        assert "gate" in out


### PR DESCRIPTION
## Summary
- `build_response_instructions` previously returned `None` for any chip without `pronoun`/`verb`, so vocab encounters had zero per-turn guidance and the realtime model only saw the static `lesson_block` listing English glosses. Chips like `número de puerta`, `al`, or `los` rarely got elicited.
- Vocab chips now reuse the existing `VOCAB_ELICITATION_HINTS` from `grammar_elicitation` (reflexives, contractions, gendered articles) or fall back to a generic "ask a question whose answer requires the form" template.
- Grammar chip behavior is unchanged.

## Why now
User report from QA: in the airport encounter the avatar answered the user's question naturally but never set up turns that elicited the remaining chips. Diagnosis showed both that the FE wasn't consuming `response_instructions` (separate FE PR) AND that the BE wouldn't have produced one for vocab chips even if the FE asked.

## Test plan
- [x] `pytest tests/test_services/test_realtime_steering.py` — new file, 8 tests covering grammar + vocab + hint + fallback paths.
- [x] `pytest tests/test_services/test_grammar_elicitation.py tests/test_services/test_realtime_lesson_context.py tests/test_services/test_avatar_validator.py tests/test_services/test_anti_stuck_rule.py tests/test_services/test_chat_chip_completion.py` — 80 passed, no regressions in adjacent modules.
- [ ] Manual QA on Railway preview after merge: airport encounter, confirm avatar leads with questions whose answers require pending vocab chips.